### PR TITLE
Configuring cancellation on movement

### DIFF
--- a/src/io/github/at/commands/home/Home.java
+++ b/src/io/github/at/commands/home/Home.java
@@ -160,7 +160,7 @@ public class Home implements CommandExecutor {
                 };
                 MovementManager.getMovement().put(player, movementtimer);
                 movementtimer.runTaskLater(Main.getInstance(), Config.getTeleportTimer("home") * 20);
-                player.sendMessage(CustomMessages.getString("Teleport.eventBeforeTP").replaceAll("\\{countdown}", String.valueOf(Config.getTeleportTimer("home"))));
+                player.sendMessage(CustomMessages.getEventBeforeTPMessage().replaceAll("\\{countdown}", String.valueOf(Config.getTeleportTimer("home"))));
 
             } else {
                 player.sendMessage(CustomMessages.getString("Teleport.teleportingToHome").replaceAll("\\{home}",name));

--- a/src/io/github/at/commands/spawn/SpawnCommand.java
+++ b/src/io/github/at/commands/spawn/SpawnCommand.java
@@ -57,7 +57,7 @@ public class SpawnCommand implements CommandExecutor {
                 };
                 MovementManager.getMovement().put(player, movementtimer);
                 movementtimer.runTaskLater(Main.getInstance(), Config.getTeleportTimer("spawn") * 20);
-                player.sendMessage(CustomMessages.getString("Teleport.eventBeforeTP").replaceAll("\\{countdown}", String.valueOf(Config.getTeleportTimer("spawn"))));
+                player.sendMessage(CustomMessages.getEventBeforeTPMessage().replaceAll("\\{countdown}", String.valueOf(Config.getTeleportTimer("spawn"))));
 
             } else {
                 PaymentManager.withdraw("spawn", player);

--- a/src/io/github/at/commands/teleport/Back.java
+++ b/src/io/github/at/commands/teleport/Back.java
@@ -53,7 +53,7 @@ public class Back implements CommandExecutor {
                             };
                             MovementManager.getMovement().put(player, movementtimer);
                             movementtimer.runTaskLater(Main.getInstance(), Config.getTeleportTimer("back")*20);
-                            player.sendMessage(CustomMessages.getString("Teleport.eventBeforeTP").replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("back"))));
+                            player.sendMessage(CustomMessages.getEventBeforeTPMessage().replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("back"))));
 
                         } else {
                             player.teleport(loc);

--- a/src/io/github/at/commands/teleport/Tpr.java
+++ b/src/io/github/at/commands/teleport/Tpr.java
@@ -123,7 +123,7 @@ public class Tpr implements CommandExecutor {
             };
             MovementManager.getMovement().put(player, movementtimer);
             movementtimer.runTaskLater(Main.getInstance(), Config.getTeleportTimer("tpr") * 20);
-            player.sendMessage(CustomMessages.getString("Teleport.eventBeforeTP").replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("tpr"))));
+            player.sendMessage(CustomMessages.getEventBeforeTPMessage().replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("tpr"))));
             return false;
 
         } else {

--- a/src/io/github/at/commands/warp/Warp.java
+++ b/src/io/github/at/commands/warp/Warp.java
@@ -122,7 +122,7 @@ public class Warp implements CommandExecutor {
                 };
                 MovementManager.getMovement().put(player, movementtimer);
                 movementtimer.runTaskLater(Main.getInstance(), Config.getTeleportTimer("warp")*20);
-                player.sendMessage(CustomMessages.getString("Teleport.eventBeforeTP").replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("warp"))));
+                player.sendMessage(CustomMessages.getEventBeforeTPMessage().replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("warp"))));
 
             } else {
                 player.teleport(loc);

--- a/src/io/github/at/config/Config.java
+++ b/src/io/github/at/config/Config.java
@@ -41,6 +41,7 @@ public class Config {
       
         config.addDefault("timers.requestLifetime",60);
         config.addDefault("timers.cancel-on-rotate", false);
+        config.addDefault("timers.cancel-on-movement", true);
         // Booleans
         config.addDefault("booleans.useVault" , false);
         config.addDefault("booleans.EXPPayment" , false);
@@ -196,6 +197,8 @@ public class Config {
     public static boolean isFeatureEnabled(String feature) { return config.getBoolean("features." + feature); }
 
     public static boolean cancelOnRotate() {return config.getBoolean("timers.cancel-on-rotate");}
+
+    public static boolean cancelOnMovement() {return config.getBoolean("timers.cancel-on-movement");}
 
     public static void reloadConfig() throws IOException {
         if (configFile == null) {

--- a/src/io/github/at/config/CustomMessages.java
+++ b/src/io/github/at/config/CustomMessages.java
@@ -22,6 +22,7 @@ public class CustomMessages {
 
     public static void setDefaults() throws IOException {
         Config.addDefault("Teleport.eventBeforeTP" , "&aTeleporting in &b{countdown} seconds&a, please do not move!");
+        Config.addDefault("Teleport.eventBeforeTPMovementAllowed" , "&aTeleporting in &b{countdown} seconds&a!");
         Config.addDefault("Teleport.eventTeleport" , "&aTeleporting...");
         Config.addDefault("Teleport.eventMovement" , "&cTeleport has been cancelled due to movement.");
         Config.addDefault("Teleport.teleportingToSpawn", "&aTeleporting you to spawn!");
@@ -186,5 +187,13 @@ public class CustomMessages {
         Config = YamlConfiguration.loadConfiguration(ConfigFile);
         setDefaults();
         save();
+    }
+
+    public static String getEventBeforeTPMessage() {
+        if(Config.getBoolean("timers.cancel-on-movement")) {
+            return getString("Teleport.eventBeforeTP");
+        } else {
+            return getString("Teleport.eventBeforeTPMovementAllowed");
+        }
     }
 }

--- a/src/io/github/at/config/CustomMessages.java
+++ b/src/io/github/at/config/CustomMessages.java
@@ -190,7 +190,7 @@ public class CustomMessages {
     }
 
     public static String getEventBeforeTPMessage() {
-        if(Config.getBoolean("timers.cancel-on-movement")) {
+        if(io.github.at.config.Config.cancelOnMovement()) {
             return getString("Teleport.eventBeforeTP");
         } else {
             return getString("Teleport.eventBeforeTPMovementAllowed");

--- a/src/io/github/at/events/MovementManager.java
+++ b/src/io/github/at/events/MovementManager.java
@@ -26,7 +26,7 @@ public class MovementManager implements Listener {
                 return;
             }
         }
-        if (movement.containsKey(event.getPlayer())) {
+        if (Config.cancelOnMovement() && movement.containsKey(event.getPlayer())) {
             BukkitRunnable timer = movement.get(event.getPlayer());
             timer.cancel();
             event.getPlayer().sendMessage(CustomMessages.getString("Teleport.eventMovement"));

--- a/src/io/github/at/utilities/AcceptRequest.java
+++ b/src/io/github/at/utilities/AcceptRequest.java
@@ -29,7 +29,7 @@ public class AcceptRequest {
                     };
                     MovementManager.getMovement().put(player, movementtimer);
                     movementtimer.runTaskLater(Main.getInstance(), Config.getTeleportTimer("tpahere")*20);
-                    player.sendMessage(CustomMessages.getString("Teleport.eventBeforeTP").replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("tpahere"))));
+                    player.sendMessage(CustomMessages.getEventBeforeTPMessage().replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("tpahere"))));
                 } else {
                     player.teleport(request.getRequester());
                     player.sendMessage(CustomMessages.getString("Teleport.eventTeleport"));
@@ -48,7 +48,7 @@ public class AcceptRequest {
                     };
                     MovementManager.getMovement().put(request.getRequester(), movementtimer);
                     movementtimer.runTaskLater(Main.getInstance(), Config.getTeleportTimer("tpa")*20);
-                    request.getRequester().sendMessage(CustomMessages.getString("Teleport.eventBeforeTP").replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("tpa"))));
+                    request.getRequester().sendMessage(CustomMessages.getEventBeforeTPMessage().replaceAll("\\{countdown}" , String.valueOf(Config.getTeleportTimer("tpa"))));
 
                 } else {
                     request.getRequester().teleport(player);


### PR DESCRIPTION
With another TP plugin, I was able to move while waiting for the teleport to happen - and the server users liked this (more forgiving) way.

I added a global config item to enable this (including the message to be sent) - I hope you'll like it.

If you have any issues, let me know in this PR.