### PR TITLE
Remove trailing comma from home list

### DIFF
--- a/src/io/github/at/commands/home/HomesCommand.java
+++ b/src/io/github/at/commands/home/HomesCommand.java
@@ -26,6 +26,7 @@ public class HomesCommand implements CommandExecutor {
                                         for (String home: Homes.getHomes(player).keySet()) {
                                             hlist.append(home + ", ");
                                         }
+                                        hlist.setLength(hlist.length() - 2);
                                     } else {
                                         sender.sendMessage(CustomMessages.getString("Error.noHomesOther").replaceAll("\\{player}", player.getName()));
                                         return false;
@@ -50,6 +51,7 @@ public class HomesCommand implements CommandExecutor {
                             for (String home: Homes.getHomes(player).keySet()) {
                                 hlist.append(home + ", ");
                             }
+                            hlist.setLength(hlist.length() - 2);
                         } else {
                             sender.sendMessage(CustomMessages.getString("Error.noHomes"));
                             return false;


### PR DESCRIPTION
Previously, it will show trailing comma when you are using `/homes` command, like:
`Homes: home1, home2, `
Now it's:
`Homes: home1, home2`