### PR TITLE
Add clickable warps and homes

### DIFF
--- a/src/io/github/at/commands/home/HomesCommand.java
+++ b/src/io/github/at/commands/home/HomesCommand.java
@@ -1,5 +1,6 @@
 package io.github.at.commands.home;
 
+import fanciful.FancyMessage;
 import io.github.at.config.Config;
 import io.github.at.config.CustomMessages;
 import io.github.at.config.Homes;
@@ -44,14 +45,20 @@ public class HomesCommand implements CommandExecutor {
                 }
                 if (sender instanceof Player) {
                     Player player = (Player)sender;
-                    StringBuilder hlist = new StringBuilder();
-                    hlist.append(CustomMessages.getString("Info.homes"));
+                    FancyMessage hList = new FancyMessage();
+                    hList.text(CustomMessages.getString("Info.homes"));
                     try {
                         if (Homes.getHomes(player).size()>0){
+
                             for (String home: Homes.getHomes(player).keySet()) {
-                                hlist.append(home + ", ");
+                                hList.then(home)
+                                        .command("/home " + home)
+                                        .tooltip(CustomMessages.getString("Tooltip.homes").replaceAll("\\{home}", home));
+                                hList.then(", ");
                             }
-                            hlist.setLength(hlist.length() - 2);
+
+                            hList.text("");
+
                         } else {
                             sender.sendMessage(CustomMessages.getString("Error.noHomes"));
                             return false;
@@ -60,7 +67,7 @@ public class HomesCommand implements CommandExecutor {
                         sender.sendMessage(CustomMessages.getString("Error.noHomes"));
                         return false;
                     }
-                    sender.sendMessage(hlist.toString());
+                    hList.send(player);
                 }
             }
         } else {

--- a/src/io/github/at/commands/home/HomesCommand.java
+++ b/src/io/github/at/commands/home/HomesCommand.java
@@ -49,20 +49,18 @@ public class HomesCommand implements CommandExecutor {
                     hList.text(CustomMessages.getString("Info.homes"));
                     try {
                         if (Homes.getHomes(player).size()>0){
-
                             for (String home: Homes.getHomes(player).keySet()) {
                                 hList.then(home)
                                         .command("/home " + home)
                                         .tooltip(CustomMessages.getString("Tooltip.homes").replaceAll("\\{home}", home));
                                 hList.then(", ");
                             }
-
                             hList.text("");
-
                         } else {
                             sender.sendMessage(CustomMessages.getString("Error.noHomes"));
                             return false;
                         }
+
                     } catch (NullPointerException ex) { // If a player has never set any homes
                         sender.sendMessage(CustomMessages.getString("Error.noHomes"));
                         return false;

--- a/src/io/github/at/commands/warp/WarpsCommand.java
+++ b/src/io/github/at/commands/warp/WarpsCommand.java
@@ -1,5 +1,6 @@
 package io.github.at.commands.warp;
 
+import fanciful.FancyMessage;
 import io.github.at.config.Config;
 import io.github.at.config.CustomMessages;
 import io.github.at.config.Warps;
@@ -12,15 +13,18 @@ public class WarpsCommand implements CommandExecutor {
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
         if (Config.isFeatureEnabled("warps")) {
             if (commandSender.hasPermission("at.member.warps")){
-                StringBuilder wList = new StringBuilder();
-                wList.append(CustomMessages.getString("Info.warps"));
+                FancyMessage wList = new FancyMessage();
+                wList.text(CustomMessages.getString("Info.warps"));
                 for (String warp: Warps.getWarps().keySet()) {
                     if (commandSender.hasPermission("at.member.warp.*") || commandSender.hasPermission("at.member.warp." + warp)) {
-                        wList.append(warp + ", ");
+                        wList.then(warp)
+                                .command("/warp " + warp)
+                                .tooltip(CustomMessages.getString("Tooltip.warps").replaceAll("\\{warp}", warp));
+                        wList.then(", ");
                     }
-
+                    wList.text("");
                 }
-                commandSender.sendMessage(wList.toString());
+                wList.send(commandSender);
             }
         } else {
             commandSender.sendMessage(CustomMessages.getString("Error.featureDisabled"));

--- a/src/io/github/at/config/CustomMessages.java
+++ b/src/io/github/at/config/CustomMessages.java
@@ -124,6 +124,8 @@ public class CustomMessages {
         Config.addDefault("Info.createdRTPSign", "&aSuccessfully created the RandomTP sign!");
         Config.addDefault("Info.createdSpawnSign", "&aSuccessfully created the spawn sign!");
         Config.addDefault("Info.tpallRequestSent", "&aSuccessfully sent a teleport request to &e{amount} &aplayer(s)!");
+        Config.addDefault("Tooltip.homes", "&aTeleports you to your home: &e{home}");
+        Config.addDefault("Tooltip.warps", "&aTeleports you to warp: &e{warp}");
         Config.addDefault("Help.mainHelp", new ArrayList<>(Arrays.asList("&b&lAdvancedTeleport Help",
                 "&6Please type &b/athelp <category> &6to get a list of commands about this category.",
                 "&6--[ &bCategories &6]--",


### PR DESCRIPTION
Allows you to click home name on the `/homes` list and warp name on the `/warps` list to teleport.
(Also removes the trailing comma on `/warps`)