### PR TITLE
Added configuration option for when to apply the command cooldowns

### DIFF
--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/home/Home.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/home/Home.java
@@ -148,7 +148,11 @@ public class Home implements CommandExecutor {
             ATTeleportEvent event = new ATTeleportEvent(player, loc, player.getLocation(), name, ATTeleportEvent.TeleportType.HOME);
             if (!event.isCancelled()) {
                 if (PaymentManager.getInstance().canPay("home", player)) {
-                    CooldownManager.addToCooldown("home", player);
+                    // If the cooldown is to be applied after request or accept (they are the same in the case of /home), apply it now
+                    String cooldownConfig = NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get();
+                    if(cooldownConfig.equalsIgnoreCase("request") || cooldownConfig.equalsIgnoreCase("accept")) {
+                        CooldownManager.addToCooldown("home", player);
+                    }
                     int warmUp = NewConfig.getInstance().WARM_UPS.HOME.get();
                     if (warmUp > 0 && !player.hasPermission("at.admin.bypass.timer")) {
                         MovementManager.createMovementTimer(player, loc, "home", "Teleport.teleportingToHome", warmUp, "\\{home}", name);

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/spawn/SpawnCommand.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/spawn/SpawnCommand.java
@@ -55,7 +55,11 @@ public class SpawnCommand implements CommandExecutor {
         ATTeleportEvent event = new ATTeleportEvent(player, spawn, player.getLocation(), "spawn", ATTeleportEvent.TeleportType.SPAWN);
         if (!event.isCancelled()) {
             if (PaymentManager.getInstance().canPay("spawn", player)) {
-                CooldownManager.addToCooldown("spawn", player);
+                // If the cooldown is to be applied after request or accept (they are the same in the case of /spawn), apply it now
+                String cooldownConfig = NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get();
+                if(cooldownConfig.equalsIgnoreCase("request") || cooldownConfig.equalsIgnoreCase("accept")) {
+                    CooldownManager.addToCooldown("spawn", player);
+                }
                 int warmUp = NewConfig.getInstance().WARM_UPS.SPAWN.get();
                 if (warmUp > 0 && !player.hasPermission("at.admin.bypass.timer")) {
                     MovementManager.createMovementTimer(player, spawn, "spawn", "Teleport.teleportingToSpawn", warmUp);

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Back.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Back.java
@@ -68,7 +68,11 @@ public class Back implements CommandExecutor {
                                
                                 player.sendMessage(CustomMessages.getString("Teleport.teleportingToLastLoc"));
                             }
-                            CooldownManager.addToCooldown("back", player);
+                            // If the cooldown is to be applied after request or accept (they are the same in the case of /back), apply it now
+                            String cooldownConfig = NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get();
+                            if(cooldownConfig.equalsIgnoreCase("request") || cooldownConfig.equalsIgnoreCase("accept")) {
+                                CooldownManager.addToCooldown("back", player);
+                            }
                         }
                     }
 

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpAll.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpAll.java
@@ -25,7 +25,7 @@ public class TpAll implements CommandExecutor {
                 if (sender.hasPermission("at.admin.all")) {
                     Player player = (Player) sender;
                     UUID playerUuid = player.getUniqueId();
-                    int cooldown = CooldownManager.secondsLeftOnCooldown("tpaall", player);
+                    int cooldown = CooldownManager.secondsLeftOnCooldown("tpahere", player);
                     if (cooldown > 0) {
                         sender.sendMessage(CustomMessages.getString("Error.onCooldown").replaceAll("\\{time}", String.valueOf(cooldown)));
                         return true;

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpAll.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpAll.java
@@ -57,6 +57,7 @@ public class TpAll implements CommandExecutor {
                             run.runTaskLater(CoreClass.getInstance(), requestLifetime * 20); // 60 seconds
                             TPRequest request = new TPRequest(player, target, run, TPRequest.TeleportType.TPAHERE); // Creates a new teleport request.
                             TPRequest.addRequest(request);
+                            // Cooldown for tpall is always applied after request
                             CooldownManager.addToCooldown("tpaall", player);
                         }
                     }

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpYes.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpYes.java
@@ -1,6 +1,8 @@
 package io.github.niestrat99.advancedteleport.commands.teleport;
 
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
+import io.github.niestrat99.advancedteleport.config.NewConfig;
+import io.github.niestrat99.advancedteleport.events.CooldownManager;
 import io.github.niestrat99.advancedteleport.utilities.AcceptRequest;
 import io.github.niestrat99.advancedteleport.utilities.TPRequest;
 import io.github.niestrat99.advancedteleport.utilities.TeleportTests;
@@ -20,6 +22,10 @@ public class TpYes implements CommandExecutor {
                 if (request != null) {
                     // It's not null, we've already run the tests to make sure it isn't
                     AcceptRequest.acceptRequest(request);
+                    // If the cooldown is to be applied after the request is accepted, apply it now
+                    if(NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("accept")) {
+                        CooldownManager.addToCooldown(request.getType() == TPRequest.TeleportType.TPAHERE ? "tpahere" : "tpa", request.getRequester());
+                    }
                 }
             } else {
                 sender.sendMessage(CustomMessages.getString("Error.notAPlayer"));

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpa.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpa.java
@@ -64,7 +64,10 @@ public class Tpa implements CommandExecutor {
                                 run.runTaskLater(CoreClass.getInstance(), requestLifetime * 20); // 60 seconds
                                 TPRequest request = new TPRequest(player, target, run, TPRequest.TeleportType.TPA); // Creates a new teleport request.
                                 TPRequest.addRequest(request);
-                                CooldownManager.addToCooldown("tpa", player);
+                                // If the cooldown is to be applied after request, apply it now
+                                if(NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("request")) {
+                                    CooldownManager.addToCooldown("tpa", player);
+                                }
                                 return true;
                             }
                         } else {

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpaHere.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpaHere.java
@@ -63,7 +63,10 @@ public class TpaHere implements CommandExecutor {
                                 run.runTaskLater(CoreClass.getInstance(), requestLifetime * 20); // 60 seconds
                                 TPRequest request = new TPRequest(player, target, run, TPRequest.TeleportType.TPAHERE); // Creates a new teleport request.
                                 TPRequest.addRequest(request);
-                                CooldownManager.addToCooldown("tpahere", player);
+                                // If the cooldown is to be applied after request or accept (they are the same in the case of /spawn), apply it now
+                                if(NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("request")) {
+                                    CooldownManager.addToCooldown("tpahere", player);
+                                }
                                 return true;
                             }
                         } else {

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
@@ -86,7 +86,11 @@ public class Tpr implements CommandExecutor {
         RandomTPAlgorithms.getAlgorithms().get("binary").fire(player, world, location -> Bukkit.getScheduler().runTask(CoreClass.getInstance(), () -> {
             ATTeleportEvent event = new ATTeleportEvent(player, location, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
             if (!event.isCancelled()) {
-                CooldownManager.addToCooldown("tpr", player);
+                // If the cooldown is to be applied after request or accept (they are the same in the case of /tpr), apply it now
+                String cooldownConfig = NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get();
+                if(cooldownConfig.equalsIgnoreCase("request") || cooldownConfig.equalsIgnoreCase("accept")) {
+                    CooldownManager.addToCooldown("tpr", player);
+                }
                 int warmUp = NewConfig.getInstance().WARM_UPS.TPR.get();
                 if (warmUp > 0 && !player.hasPermission("at.admin.bypass.timer")) {
                     MovementManager.createMovementTimer(player, location, "tpr", "Teleport.teleportingToRandomPlace", warmUp);

--- a/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/Warp.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/Warp.java
@@ -121,7 +121,11 @@ public class Warp implements CommandExecutor {
                 int warmUp = NewConfig.getInstance().WARM_UPS.WARP.get();
                 if (warmUp > 0 && !player.hasPermission("at.admin.bypass.timer")) {
                     MovementManager.createMovementTimer(player, loc, "warp", "Teleport.teleportingToWarp", warmUp, "\\{warp}", name);
-                    CooldownManager.addToCooldown("warp", player);
+                    // If the cooldown is to be applied after request or accept (they are the same in the case of /warp), apply it now
+                    String cooldownConfig = NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get();
+                    if(cooldownConfig.equalsIgnoreCase("request") || cooldownConfig.equalsIgnoreCase("accept")) {
+                        CooldownManager.addToCooldown("warp", player);
+                    }
                 } else {
                     PaymentManager.getInstance().withdraw("warp", player);
                     PaperLib.teleportAsync(player, loc, PlayerTeleportEvent.TeleportCause.COMMAND);

--- a/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -412,7 +412,17 @@ public class NewConfig extends CMFile {
         COOLDOWN_TIMER_DURATION = new ConfigOption<>("cooldown-duration");
         ADD_COOLDOWN_DURATION_TO_WARM_UP = new ConfigOption<>("add-cooldown-duration-to-warm-up");
         APPLY_COOLDOWN_TO_ALL_COMMANDS = new ConfigOption<>("apply-cooldown-to-all-commands");
+
         APPLY_COOLDOWN_AFTER = new ConfigOption<>("apply-cooldown-after");
+        switch (APPLY_COOLDOWN_AFTER.get().toLowerCase()) {
+            case "accept":
+            case "request":
+            case "teleport":
+                break;
+            default:
+                CoreClass.getInstance().getLogger().warning("Bad input for apply-cooldown-after option! Using \"request\" as the default option...");
+                set("apply-cooldown-after", "request");
+        }
         COOLDOWNS = new PerCommandOption<>("per-command-cooldowns", "cooldown-duration");
 
         COST_AMOUNT = new ConfigOption<>("cost-amount");

--- a/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -32,6 +32,7 @@ public class NewConfig extends CMFile {
     public ConfigOption<Integer> COOLDOWN_TIMER_DURATION;
     public ConfigOption<Boolean> ADD_COOLDOWN_DURATION_TO_WARM_UP;
     public ConfigOption<Boolean> APPLY_COOLDOWN_TO_ALL_COMMANDS;
+    public ConfigOption<String> APPLY_COOLDOWN_AFTER;
     public PerCommandOption<Integer> COOLDOWNS;
 
     public ConfigOption<Object> COST_AMOUNT;
@@ -125,6 +126,14 @@ public class NewConfig extends CMFile {
         addDefault("apply-cooldown-to-all-commands", false, "Whether or not the cooldown of one command will stop a user from using all commands.\n" +
                 "For example, if a player used /tpa with a cooldown of 10 seconds but then used /tpahere with a cooldown of 5, the 10-second cooldown would still apply.\n" +
                 "On the other hand, if a player used /tpahere, the cooldown of 5 seconds would apply to /tpa and other commands.");
+        addDefault("apply-cooldown-after", "request", "When to apply the cooldown\n" +
+                        "Options include:\n" +
+                        "- request - Cooldown starts as soon as any teleport command is made and still applies even if no teleport takes place (i.e. cancelled by movement or not accepted).\n" +
+                        "- accept - Cooldown starts only when the teleport request is accepted (with /tpyes) and still applies even if no teleport takes place (i.e. cancelled by movement).\n" +
+                        "- teleport - Cooldown starts only when the teleport actually happens.\n" +
+                        "Note:\n" +
+                        "'request' and 'accept' behave the same for /rtp, /back, /spawn, /warp, and /home\n" +
+                        "cooldown for /tpall always starts when the command is ran, regardless if any player accepts or teleports");
 
         addComment("per-command-cooldowns", "Command-specific cooldowns.");
         addDefault("per-command-cooldowns.tpa", "default", "Cooldown for /tpa.");
@@ -403,6 +412,7 @@ public class NewConfig extends CMFile {
         COOLDOWN_TIMER_DURATION = new ConfigOption<>("cooldown-duration");
         ADD_COOLDOWN_DURATION_TO_WARM_UP = new ConfigOption<>("add-cooldown-duration-to-warm-up");
         APPLY_COOLDOWN_TO_ALL_COMMANDS = new ConfigOption<>("apply-cooldown-to-all-commands");
+        APPLY_COOLDOWN_AFTER = new ConfigOption<>("apply-cooldown-after");
         COOLDOWNS = new PerCommandOption<>("per-command-cooldowns", "cooldown-duration");
 
         COST_AMOUNT = new ConfigOption<>("cost-amount");

--- a/src/main/java/io/github/niestrat99/advancedteleport/events/MovementManager.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/events/MovementManager.java
@@ -5,6 +5,7 @@ import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.Config;
 import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.payments.PaymentManager;
+import io.github.niestrat99.advancedteleport.utilities.TPRequest;
 import io.papermc.lib.PaperLib;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -67,7 +68,10 @@ public class MovementManager implements Listener {
 
                 teleportingPlayer.sendMessage(finalMessage);
                 PaymentManager.getInstance().withdraw(command, payingPlayer);
-
+                // If the cooldown is to be applied after only after a teleport takes place, apply it now
+                if(NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("teleport")) {
+                    CooldownManager.addToCooldown(command, payingPlayer);
+                }
             }
         };
         movement.put(uuid, movementtimer);

--- a/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
@@ -41,7 +41,7 @@ public class AcceptRequest {
             } else {
                 PaperLib.teleportAsync(fromPlayer, toPlayer.getLocation(), PlayerTeleportEvent.TeleportCause.COMMAND);
                 fromPlayer.sendMessage(CustomMessages.getString("Teleport.eventTeleport"));
-                PaymentManager.getInstance().withdraw("tpahere", payingPlayer);
+                PaymentManager.getInstance().withdraw(type, payingPlayer);
                 // If the cooldown is to be applied after only after a teleport takes place, apply it now
                 if(NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("teleport")) {
                     CooldownManager.addToCooldown(type, payingPlayer);

--- a/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
+++ b/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
@@ -4,6 +4,7 @@ import io.github.niestrat99.advancedteleport.api.ATTeleportEvent;
 import io.github.niestrat99.advancedteleport.config.Config;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.NewConfig;
+import io.github.niestrat99.advancedteleport.events.CooldownManager;
 import io.github.niestrat99.advancedteleport.events.MovementManager;
 import io.github.niestrat99.advancedteleport.CoreClass;
 import io.github.niestrat99.advancedteleport.payments.PaymentManager;
@@ -41,6 +42,10 @@ public class AcceptRequest {
                 PaperLib.teleportAsync(fromPlayer, toPlayer.getLocation(), PlayerTeleportEvent.TeleportCause.COMMAND);
                 fromPlayer.sendMessage(CustomMessages.getString("Teleport.eventTeleport"));
                 PaymentManager.getInstance().withdraw("tpahere", payingPlayer);
+                // If the cooldown is to be applied after only after a teleport takes place, apply it now
+                if(NewConfig.getInstance().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("teleport")) {
+                    CooldownManager.addToCooldown(type, payingPlayer);
+                }
             }
         }
     }


### PR DESCRIPTION
The new configuration option is called `apply-cooldown-after`

Valid options are:
- `request` - Cooldown starts as soon as any teleport command is made and still applies even if no teleport takes place (i.e. cancelled by movement or not accepted).
- `accept` - Cooldown starts only when the teleport request is accepted (with `/tpyes`) and still applies even if no teleport takes place (i.e. cancelled by movement).
- `teleport` - Cooldown starts only when the teleport actually happens.

Note:
`request` and `accept` behave the same for `/rtp,` `/back`, `/spawn`, `/warp`, and `/home`.
 Cooldown for `/tpall` always starts when the command is ran, regardless if any player accepts it or teleports.
`request` is the default to maintain the same behaviour, although `teleport` may make more sense from a player's viewpoint.