### PR TITLE
Rapid Response RTP System

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/CoreClass.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/CoreClass.java
@@ -7,6 +7,7 @@ import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.config.Spawn;
 import io.github.niestrat99.advancedteleport.listeners.AtSigns;
 import io.github.niestrat99.advancedteleport.listeners.PlayerListeners;
+import io.github.niestrat99.advancedteleport.listeners.WorldLoadListener;
 import io.github.niestrat99.advancedteleport.managers.*;
 import io.github.niestrat99.advancedteleport.sql.*;
 import io.github.niestrat99.advancedteleport.utilities.RandomTPAlgorithms;
@@ -135,6 +136,7 @@ public class CoreClass extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new TeleportTrackingManager(), this);
         getServer().getPluginManager().registerEvents(new MovementManager(), this);
         getServer().getPluginManager().registerEvents(new PlayerListeners(), this);
+        getServer().getPluginManager().registerEvents(new WorldLoadListener(), this);
     }
 
     public static void playSound(String type, String subType, Player target) {

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/CoreClass.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/CoreClass.java
@@ -7,10 +7,7 @@ import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.config.Spawn;
 import io.github.niestrat99.advancedteleport.listeners.AtSigns;
 import io.github.niestrat99.advancedteleport.listeners.PlayerListeners;
-import io.github.niestrat99.advancedteleport.managers.CommandManager;
-import io.github.niestrat99.advancedteleport.managers.CooldownManager;
-import io.github.niestrat99.advancedteleport.managers.MovementManager;
-import io.github.niestrat99.advancedteleport.managers.TeleportTrackingManager;
+import io.github.niestrat99.advancedteleport.managers.*;
 import io.github.niestrat99.advancedteleport.sql.*;
 import io.github.niestrat99.advancedteleport.utilities.RandomTPAlgorithms;
 import io.github.niestrat99.advancedteleport.utilities.nbt.NBTReader;
@@ -114,6 +111,7 @@ public class CoreClass extends JavaPlugin {
             public void run() {
                 // Config.setupDefaults();
                 NBTReader.init();
+                RTPManager.init();
                 Object[] update = UpdateChecker.getUpdate();
                 if (update != null) {
                     getServer().getConsoleSender().sendMessage(pltitle(ChatColor.AQUA + "" + ChatColor.BOLD + "A new version is available!") + "\n" + pltitle(ChatColor.AQUA + "" + ChatColor.BOLD + "Current version you're using: " + ChatColor.WHITE + getDescription().getVersion()) + "\n" + pltitle(ChatColor.AQUA + "" + ChatColor.BOLD + "Latest version available: " + ChatColor.WHITE + update[0]));

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
@@ -1,5 +1,6 @@
 package io.github.niestrat99.advancedteleport.commands.teleport;
 
+import io.github.niestrat99.advancedteleport.CoreClass;
 import io.github.niestrat99.advancedteleport.api.ATPlayer;
 import io.github.niestrat99.advancedteleport.api.events.ATTeleportEvent;
 import io.github.niestrat99.advancedteleport.commands.ATCommand;
@@ -10,6 +11,8 @@ import io.github.niestrat99.advancedteleport.managers.MovementManager;
 import io.github.niestrat99.advancedteleport.managers.RTPManager;
 import io.github.niestrat99.advancedteleport.payments.PaymentManager;
 import io.github.niestrat99.advancedteleport.utilities.ConditionChecker;
+import io.github.niestrat99.advancedteleport.utilities.RandomTPAlgorithms;
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -114,23 +117,33 @@ public class Tpr implements ATCommand {
 
         if (!PaymentManager.getInstance().canPay("tpr", player)) return false;
 
-
-        Location nextLoc = RTPManager.getLocationUrgently(world);
-        if (nextLoc != null) {
-            searchingPlayers.remove(player.getUniqueId());
-            ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            ATTeleportEvent event = new ATTeleportEvent(player, nextLoc, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
-            atPlayer.teleport(event, "tpr", "Teleport.teleportingToRandomPlace", NewConfig.get().WARM_UPS.TPR.get());
+        if (NewConfig.get().RAPID_RESPONSE.get() && PaperLib.isPaper()) {
+            Location nextLoc = RTPManager.getLocationUrgently(world);
+            if (nextLoc != null) {
+                ATPlayer atPlayer = ATPlayer.getPlayer(player);
+                ATTeleportEvent event = new ATTeleportEvent(player, nextLoc, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
+                atPlayer.teleport(event, "tpr", "Teleport.teleportingToRandomPlace", NewConfig.get().WARM_UPS.TPR.get());
+            } else {
+                CustomMessages.sendMessage(player, "Info.searching");
+                searchingPlayers.add(player.getUniqueId());
+                RTPManager.getNextAvailableLocation(world).thenAccept(location -> {
+                    searchingPlayers.remove(player.getUniqueId());
+                    ATPlayer atPlayer = ATPlayer.getPlayer(player);
+                    ATTeleportEvent event = new ATTeleportEvent(player, location, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
+                    atPlayer.teleport(event, "tpr", "Teleport.teleportingToRandomPlace", NewConfig.get().WARM_UPS.TPR.get());
+                });
+            }
         } else {
             CustomMessages.sendMessage(player, "Info.searching");
             searchingPlayers.add(player.getUniqueId());
-            RTPManager.getNextAvailableLocation(world).thenAccept(location -> {
+            RandomTPAlgorithms.getAlgorithms().get("binary").fire(player, world, location -> Bukkit.getScheduler().runTask(CoreClass.getInstance(), () -> {
                 searchingPlayers.remove(player.getUniqueId());
                 ATPlayer atPlayer = ATPlayer.getPlayer(player);
                 ATTeleportEvent event = new ATTeleportEvent(player, location, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
                 atPlayer.teleport(event, "tpr", "Teleport.teleportingToRandomPlace", NewConfig.get().WARM_UPS.TPR.get());
-            });
+            }));
         }
+
         return true;
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
@@ -1,6 +1,5 @@
 package io.github.niestrat99.advancedteleport.commands.teleport;
 
-import io.github.niestrat99.advancedteleport.CoreClass;
 import io.github.niestrat99.advancedteleport.api.ATPlayer;
 import io.github.niestrat99.advancedteleport.api.events.ATTeleportEvent;
 import io.github.niestrat99.advancedteleport.commands.ATCommand;
@@ -8,9 +7,9 @@ import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.managers.CooldownManager;
 import io.github.niestrat99.advancedteleport.managers.MovementManager;
+import io.github.niestrat99.advancedteleport.managers.RTPManager;
 import io.github.niestrat99.advancedteleport.payments.PaymentManager;
 import io.github.niestrat99.advancedteleport.utilities.ConditionChecker;
-import io.github.niestrat99.advancedteleport.utilities.RandomTPAlgorithms;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -116,12 +115,12 @@ public class Tpr implements ATCommand {
         if (!PaymentManager.getInstance().canPay("tpr", player)) return false;
         CustomMessages.sendMessage(player, "Info.searching");
         searchingPlayers.add(player.getUniqueId());
-        RandomTPAlgorithms.getAlgorithms().get("binary").fire(player, world, location -> Bukkit.getScheduler().runTask(CoreClass.getInstance(), () -> {
+        RTPManager.getNextAvailableLocation(world).thenAccept(location -> {
             searchingPlayers.remove(player.getUniqueId());
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
             ATTeleportEvent event = new ATTeleportEvent(player, location, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
             atPlayer.teleport(event, "tpr", "Teleport.teleportingToRandomPlace", NewConfig.get().WARM_UPS.TPR.get());
-        }));
+        });
         return true;
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpr.java
@@ -113,14 +113,24 @@ public class Tpr implements ATCommand {
         }
 
         if (!PaymentManager.getInstance().canPay("tpr", player)) return false;
-        CustomMessages.sendMessage(player, "Info.searching");
-        searchingPlayers.add(player.getUniqueId());
-        RTPManager.getNextAvailableLocation(world).thenAccept(location -> {
+
+
+        Location nextLoc = RTPManager.getLocationUrgently(world);
+        if (nextLoc != null) {
             searchingPlayers.remove(player.getUniqueId());
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            ATTeleportEvent event = new ATTeleportEvent(player, location, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
+            ATTeleportEvent event = new ATTeleportEvent(player, nextLoc, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
             atPlayer.teleport(event, "tpr", "Teleport.teleportingToRandomPlace", NewConfig.get().WARM_UPS.TPR.get());
-        });
+        } else {
+            CustomMessages.sendMessage(player, "Info.searching");
+            searchingPlayers.add(player.getUniqueId());
+            RTPManager.getNextAvailableLocation(world).thenAccept(location -> {
+                searchingPlayers.remove(player.getUniqueId());
+                ATPlayer atPlayer = ATPlayer.getPlayer(player);
+                ATTeleportEvent event = new ATTeleportEvent(player, location, player.getLocation(), "", ATTeleportEvent.TeleportType.TPR);
+                atPlayer.teleport(event, "tpr", "Teleport.teleportingToRandomPlace", NewConfig.get().WARM_UPS.TPR.get());
+            });
+        }
         return true;
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -64,6 +64,7 @@ public class NewConfig extends CMFile {
     public ConfigOption<Integer> MINIMUM_Z;
     public ConfigOption<Boolean> USE_WORLD_BORDER;
     public ConfigOption<List<String>> AVOID_BLOCKS;
+    public ConfigOption<List<String>> AVOID_BIOMES;
     public ConfigOption<Boolean> WHITELIST_WORLD;
     public ConfigOption<Boolean> REDIRECT_TO_WORLD;
     public ConfigOption<List<String>> ALLOWED_WORLDS;
@@ -265,8 +266,13 @@ public class NewConfig extends CMFile {
         addDefault("minimum-x", -5000, "The minimum X coordinate to go down to when selecting a random location.");
         addDefault("minimum-z", -5000, "The minimum Z coordinate to go down to when selecting a random location.");
         addDefault("use-world-border", true, "When WorldBorder is installed, AT will check the border of each world instead rather than using the minimum and maximum coordinates.");
+        addDefault("use-rapid-response", true, "Use the new rapid response system for RTP.\n" +
+                "This means valid locations are prepared before a user chooses to use /tpr or interact with a sign, meaning they are ready for use and can instantly TP a player.\n" +
+                "This feature allows you to use the \"tpr\" death option in the death management section further down.\n" +
+                "IMPORTANT NOTE - this feature only works on the Paper server type and any of its forks. It is not considered safe to use on Spigot or Bukkit.");
         addDefault("avoid-blocks", new ArrayList<>(Arrays.asList("WATER", "LAVA", "STATIONARY_WATER", "STATIONARY_LAVA")),
                 "Blocks that people must not be able to land in when using /tpr.");
+        addDefault("avoid-biomes", new ArrayList<>(Arrays.asList("OCEAN", "DEEP_OCEAN")), "Biomes that the plugin should avoid when searching for a location.");
         addDefault("whitelist-worlds", false, "Whether or not /tpr should only be used in the worlds listed below.");
         addDefault("redirect-to-whitelisted-worlds", true, "Whether or not players should be directed to a whitelisted world when using /tpr.\n" +
                 "When this option is disabled and the player tries to use /tpr in a non-whitelisted world, the command simply won't work.");
@@ -504,6 +510,7 @@ public class NewConfig extends CMFile {
         MINIMUM_Z = new ConfigOption<>("minimum-z");
         USE_WORLD_BORDER = new ConfigOption<>("use-world-border");
         AVOID_BLOCKS = new ConfigOption<>("avoid-blocks");
+        AVOID_BIOMES = new ConfigOption<>("avoid-biomes");
         WHITELIST_WORLD = new ConfigOption<>("whitelist-worlds");
         REDIRECT_TO_WORLD = new ConfigOption<>("redirect-to-whitelisted-worlds");
         ALLOWED_WORLDS = new ConfigOption<>("allowed-worlds");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -63,6 +63,7 @@ public class NewConfig extends CMFile {
     public ConfigOption<Integer> MINIMUM_X;
     public ConfigOption<Integer> MINIMUM_Z;
     public ConfigOption<Boolean> USE_WORLD_BORDER;
+    public ConfigOption<Boolean> RAPID_RESPONSE;
     public ConfigOption<List<String>> AVOID_BLOCKS;
     public ConfigOption<List<String>> AVOID_BIOMES;
     public ConfigOption<Boolean> WHITELIST_WORLD;
@@ -315,6 +316,7 @@ public class NewConfig extends CMFile {
                 "- bed - Teleports to the player's bed.\n" +
                 "- anchor - 1.16+ only, teleports to the player's respawn anchor. However, due to limitations with Spigot's API, it may or may not always work. (add Player#getRespawnAnchor pls)\n" +
                 "- warp:Warp Name - Teleports the player to a specified warp. For example, if you want to teleport to Hub, you'd type warp:Hub\n" +
+                "- tpr - Teleports the player to a random location. Can only be used when the rapid response system is enabled." +
                 "- {default} - Uses the default respawn option, which is spawn unless set differently.\n" +
                 "If you're using EssentialsX Spawn and want AT to take over respawn mechanics, set respawn-listener-priority in EssX's config.yml file to lowest.");
 
@@ -509,6 +511,7 @@ public class NewConfig extends CMFile {
         MINIMUM_X = new ConfigOption<>("minimum-x");
         MINIMUM_Z = new ConfigOption<>("minimum-z");
         USE_WORLD_BORDER = new ConfigOption<>("use-world-border");
+        RAPID_RESPONSE = new ConfigOption<>("use-rapid-response");
         AVOID_BLOCKS = new ConfigOption<>("avoid-blocks");
         AVOID_BIOMES = new ConfigOption<>("avoid-biomes");
         WHITELIST_WORLD = new ConfigOption<>("whitelist-worlds");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -64,6 +64,7 @@ public class NewConfig extends CMFile {
     public ConfigOption<Integer> MINIMUM_Z;
     public ConfigOption<Boolean> USE_WORLD_BORDER;
     public ConfigOption<Boolean> RAPID_RESPONSE;
+    public ConfigOption<Integer> PREPARED_LOCATIONS_LIMIT;
     public ConfigOption<List<String>> AVOID_BLOCKS;
     public ConfigOption<List<String>> AVOID_BIOMES;
     public ConfigOption<Boolean> WHITELIST_WORLD;
@@ -271,6 +272,8 @@ public class NewConfig extends CMFile {
                 "This means valid locations are prepared before a user chooses to use /tpr or interact with a sign, meaning they are ready for use and can instantly TP a player.\n" +
                 "This feature allows you to use the \"tpr\" death option in the death management section further down.\n" +
                 "IMPORTANT NOTE - this feature only works on the Paper server type and any of its forks. It is not considered safe to use on Spigot or Bukkit.");
+        addDefault("prepared-locations-limit", 3, "How many locations can be prepared per world when using AT's Rapid Response system.\n" +
+                "These are immediately prepared upon startup and when a world is loaded.");
         addDefault("avoid-blocks", new ArrayList<>(Arrays.asList("WATER", "LAVA", "STATIONARY_WATER", "STATIONARY_LAVA")),
                 "Blocks that people must not be able to land in when using /tpr.");
         addDefault("avoid-biomes", new ArrayList<>(Arrays.asList("OCEAN", "DEEP_OCEAN")), "Biomes that the plugin should avoid when searching for a location.");
@@ -512,6 +515,7 @@ public class NewConfig extends CMFile {
         MINIMUM_Z = new ConfigOption<>("minimum-z");
         USE_WORLD_BORDER = new ConfigOption<>("use-world-border");
         RAPID_RESPONSE = new ConfigOption<>("use-rapid-response");
+        PREPARED_LOCATIONS_LIMIT = new ConfigOption<>("prepared-locations-limit");
         AVOID_BLOCKS = new ConfigOption<>("avoid-blocks");
         AVOID_BIOMES = new ConfigOption<>("avoid-biomes");
         WHITELIST_WORLD = new ConfigOption<>("whitelist-worlds");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/listeners/WorldLoadListener.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/listeners/WorldLoadListener.java
@@ -1,0 +1,6 @@
+package io.github.niestrat99.advancedteleport.listeners;
+
+import org.bukkit.event.Listener;
+
+public class WorldLoadListener implements Listener {
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/listeners/WorldLoadListener.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/listeners/WorldLoadListener.java
@@ -1,6 +1,19 @@
 package io.github.niestrat99.advancedteleport.listeners;
 
+import io.github.niestrat99.advancedteleport.managers.RTPManager;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
 
 public class WorldLoadListener implements Listener {
+
+    @EventHandler
+    public void onWorldLoad(WorldLoadEvent event) {
+        RTPManager.loadWorldData(event.getWorld());
+    }
+
+    public void onWorldUnload(WorldUnloadEvent event) {
+        RTPManager.unloadWorldData(event.getWorld());
+    }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
@@ -12,7 +12,6 @@ import org.bukkit.block.Block;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static io.github.niestrat99.advancedteleport.CoreClass.worldBorder;
 

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
@@ -1,0 +1,100 @@
+package io.github.niestrat99.advancedteleport.managers;
+
+import com.wimbli.WorldBorder.BorderData;
+import io.github.niestrat99.advancedteleport.CoreClass;
+import io.github.niestrat99.advancedteleport.config.NewConfig;
+import io.papermc.lib.PaperLib;
+import org.bukkit.Bukkit;
+import org.bukkit.HeightMap;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static io.github.niestrat99.advancedteleport.CoreClass.worldBorder;
+
+public class RTPManager {
+
+    private static HashMap<UUID, Queue<Location>> locQueue;
+    private static HashMap<UUID, Double[]> borderData;
+
+    public static void init() {
+        locQueue = new HashMap<>();
+        borderData = new HashMap<>();
+        for (World loadedWorld : Bukkit.getWorlds()) {
+            addLocation(loadedWorld, false);
+            addLocation(loadedWorld, false);
+            addLocation(loadedWorld, false);
+            if (NewConfig.get().USE_WORLD_BORDER.get() && worldBorder != null) {
+                BorderData border = com.wimbli.WorldBorder.Config.Border(loadedWorld.getName());
+                if (border != null) {
+                    borderData.put(loadedWorld.getUID(), new Double[]{
+                            border.getX() - border.getRadiusX(),
+                            border.getZ() - border.getRadiusZ(),
+                            border.getX() + border.getRadiusX(),
+                            border.getZ() + border.getRadiusZ()});
+                }
+            }
+        }
+    }
+
+    public static CompletableFuture<Location> getNextAvailableLocation(World world) {
+        Queue<Location> queue = locQueue.get(world.getUID());
+        if (queue == null || queue.isEmpty()) {
+            return addLocation(world, true).thenApply(loc -> loc);
+        } else {
+            Location loc = queue.poll();
+            addLocation(world, false);
+            return CompletableFuture.completedFuture(loc);
+        }
+    }
+
+    public static Location getLocationUrgently(World world) {
+        Queue<Location> queue = locQueue.get(world.getUID());
+        if (queue.isEmpty()) {
+            return null;
+        } else {
+            return queue.remove();
+        }
+    }
+
+    public static CompletableFuture<Location> addLocation(World world, boolean urgent) {
+        int[] coords = getRandomCoords(world);
+        return PaperLib.getChunkAtAsync(world, coords[0] >> 4, coords[1] >> 4, true, urgent).thenApplyAsync(chunk -> {
+            Block block = world.getHighestBlockAt(coords[0], coords[1], HeightMap.WORLD_SURFACE);
+            if (isValidLocation(block)) {
+                Queue<Location> queue = locQueue.get(world.getUID());
+                if (queue == null) queue = new ArrayDeque<>();
+                queue.add(block.getLocation().add(0.5, 1, 0.5));
+                System.out.println("Added " + block.getLocation() + " to " + world.getName() + ", new size: " + queue.size());
+                locQueue.put(world.getUID(), queue);
+                return block.getLocation();
+            } else {
+                return addLocation(world, urgent).join();
+            }
+        }, CoreClass.async);
+    }
+
+    private static boolean isValidLocation(Block block) {
+        if (block.getType().name().equals("AIR") || block.getType().name().equals("VOID_AIR")) return false;
+        if (NewConfig.get().AVOID_BIOMES.get().contains(block.getBiome().name())) return false;
+        if (NewConfig.get().AVOID_BLOCKS.get().contains(block.getType().name())) return false;
+        return true;
+    }
+
+    private static int[] getRandomCoords(World world) {
+        Double[] bounds = borderData.getOrDefault(world.getUID(), new Double[]{
+                Double.valueOf(NewConfig.get().MINIMUM_X.get()),
+                Double.valueOf(NewConfig.get().MINIMUM_Z.get()),
+                Double.valueOf(NewConfig.get().MAXIMUM_X.get()),
+                Double.valueOf(NewConfig.get().MAXIMUM_Z.get())});
+        return new int[]{
+                (int) (new Random().nextInt((int)Math.round(bounds[2] - bounds[0]) + 1) + bounds[0]),
+                (int) (new Random().nextInt((int)Math.round(bounds[3] - bounds[1]) + 1) + bounds[1])
+        };
+    }
+
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
@@ -123,7 +123,7 @@ public class RTPManager {
             // If we've hit a dead end with the jumps...
             if (jumpAmount == 0) {
                 // Return an invalid location.
-                location.setY(0);
+                location.setY(-3);
                 return location.getBlock();
             }
             // Clone the current location.

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
@@ -62,6 +62,9 @@ public class RTPManager {
     }
 
     public static CompletableFuture<Location> addLocation(World world, boolean urgent) {
+        if (locQueue.get(world.getUID()).size() > 3) {
+            return CompletableFuture.completedFuture(locQueue.get(world.getUID()).poll());
+        }
         int[] coords = getRandomCoords(world);
         return PaperLib.getChunkAtAsync(world, coords[0] >> 4, coords[1] >> 4, true, urgent).thenApplyAsync(chunk -> {
             Block block = world.getHighestBlockAt(coords[0], coords[1], HeightMap.WORLD_SURFACE);

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
@@ -9,7 +9,9 @@ import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.config.Spawn;
 import io.github.niestrat99.advancedteleport.utilities.ConditionChecker;
 import io.papermc.lib.PaperLib;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -91,10 +93,28 @@ public class TeleportTrackingManager implements Listener {
             if (atPlayer.getPreviousLocation().getWorld() == null) return;
             ConfigurationSection deathManagement = NewConfig.get().DEATH_MANAGEMENT.get();
             String spawnCommand = deathManagement.getString(atPlayer.getPreviousLocation().getWorld().getName());
-            if (spawnCommand == null) {
+
+            if (spawnCommand == null || spawnCommand.equals("{default}")) {
                 spawnCommand = deathManagement.getString("default");
                 if (spawnCommand == null) return;
             }
+            if (spawnCommand.startsWith("tpr") && NewConfig.get().RAPID_RESPONSE.get()) {
+                World world = atPlayer.getPreviousLocation().getWorld();
+                if (spawnCommand.indexOf(':') != -1) {
+                    String worldStr = spawnCommand.substring(spawnCommand.indexOf(':'));
+                    if (!worldStr.isEmpty()) {
+                        world = Bukkit.getWorld(worldStr);
+                    }
+                }
+                if (world != null) {
+                    Location loc = RTPManager.getLocationUrgently(world);
+                    if (loc != null) {
+                        e.setRespawnLocation(loc);
+                        return;
+                    }
+                }
+            }
+
             switch (spawnCommand) {
                 case "spawn":
                     if (Spawn.getSpawnFile() != null) {

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomTPAlgorithms.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomTPAlgorithms.java
@@ -17,51 +17,6 @@ public class RandomTPAlgorithms {
     private static HashMap<String, Algorithm> algorithms = new HashMap<>();
 
     public static void init() {
-        algorithms.put("linear", (player, world, callback) -> {
-            Location location = RandomCoords.generateCoords(world);
-            boolean validLocation = false;
-            while (!validLocation) {
-                if (location.getWorld().getEnvironment() == World.Environment.NETHER) { // We'll search up instead of down in the Nether!
-                    while (location.getBlock().getType() != Material.AIR) {
-                        location.add(0, 1, 0);
-                    }
-                } else {
-                    while (location.getBlock().getType() == Material.AIR) {
-                        location.subtract(0, 1, 0);
-                    }
-                }
-
-
-                boolean b = true;
-                for (String Material: NewConfig.get().AVOID_BLOCKS.get()) {
-                    if (location.getWorld().getEnvironment() == World.Environment.NETHER) {
-                        if (location.clone().subtract(0, 1, 0).getBlock().getType().name().equalsIgnoreCase(Material)) {
-                            location = RandomCoords.generateCoords(world);
-                            b = false;
-                            break;
-                        }
-                    } else {
-                        if (location.getBlock().getType().name().equalsIgnoreCase(Material)){
-                            location = RandomCoords.generateCoords(world);
-                            b = false;
-                            break;
-                        }
-                    }
-
-                }
-                if (!DistanceLimiter.canTeleport(player.getLocation(), location, "tpr") && !player.hasPermission("at.admin.bypass.distance-limit")) {
-                    b = false;
-                }
-                if (b) {
-                    location.add(0 , 2 , 0);
-                    validLocation = true;
-                }
-            }
-            if (callback != null) {
-                callback.onSuccess(location);
-            }
-        });
-
         algorithms.put("binary", (player, world, callback) -> {
             Runnable runnable = () -> {
                 // Generate random coordinates
@@ -143,51 +98,6 @@ public class RandomTPAlgorithms {
                 Thread thread = new Thread(runnable, "AdvancedTeleport RTP Worker");
                 thread.setPriority(3);
                 thread.start();
-            }
-        });
-
-        algorithms.put("jump", (player, world, callback) -> {
-            Location location = RandomCoords.generateCoords(world);
-            boolean validLocation = false;
-            while (!validLocation) {
-                if (location.getWorld().getEnvironment() == World.Environment.NETHER) { // We'll search up instead of down in the Nether!
-                    while (location.getBlock().getType() != Material.AIR) {
-                        location.add(0, 10, 0);
-                    }
-                } else {
-                    while (location.getBlock().getType() == Material.AIR) {
-                        location.subtract(0, 10, 0);
-                    }
-                }
-
-
-                boolean b = true;
-                for (String Material: NewConfig.get().AVOID_BLOCKS.get()) {
-                    if (location.getWorld().getEnvironment() == World.Environment.NETHER) {
-                        if (location.clone().subtract(0, 1, 0).getBlock().getType().name().equalsIgnoreCase(Material)) {
-                            location = RandomCoords.generateCoords(world);
-                            b = false;
-                            break;
-                        }
-                    } else {
-                        if (location.getBlock().getType().name().equalsIgnoreCase(Material)){
-                            location = RandomCoords.generateCoords(world);
-                            b = false;
-                            break;
-                        }
-                    }
-
-                }
-                if (!DistanceLimiter.canTeleport(player.getLocation(), location, "tpr") && !player.hasPermission("at.admin.bypass.distance-limit")) {
-                    b = false;
-                }
-                if (b) {
-                    location.add(0 , 2 , 0);
-                    validLocation = true;
-                }
-            }
-            if (callback != null) {
-                callback.onSuccess(location);
             }
         });
     }


### PR DESCRIPTION
The Rapid Response system for /rtp is a new system that pre-determines locations to teleport to. It is only usable on Paper and its forks at this time as it is deemed unsafe for Bukkit and Spigot servers, which will use the normal RTP system. This system is mainly suitable for overworld type worlds, less Nether and End worlds, similar to the prior system. It is additionally combined with the normal system (binary jumper) to provide faster results than the standard getHighestBlock seems to run at - it also allows it to work in "hollow" worlds such as the Nether.

Implementing this feature also means being able to implement the tpr death option as suggested on Discord a while ago, since PlayerRespawnEvent operates entirely in sync. Forcing the server to search for a location on the spot would be insufficient - it must have a location prepared beforehand, async of course. 

Passive location searches are marked as not urgent so any tasks the server needs to get done of higher priority can be done first. However, if a location is not prepared and /tpr is called, the plugin will raise an urgent request to get it done as soon as possible.