### PR TITLE
Feature: Improved RTP min and max coords + per world settings + claim plugin hooks

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/core/ReloadCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/core/ReloadCommand.java
@@ -5,6 +5,7 @@ import io.github.niestrat99.advancedteleport.commands.SubATCommand;
 import io.github.niestrat99.advancedteleport.config.*;
 import io.github.niestrat99.advancedteleport.managers.CommandManager;
 import io.github.niestrat99.advancedteleport.managers.CooldownManager;
+import io.github.niestrat99.advancedteleport.utilities.RandomCoords;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +29,7 @@ public class ReloadCommand implements SubATCommand {
                 ex.printStackTrace();
             }
         }
+        RandomCoords.reload();
         CooldownManager.init();
         CommandManager.registerCommands();
         CustomMessages.sendMessage(sender, "Info.reloadedConfig");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -337,11 +337,32 @@ public class NewConfig extends ATConfig {
         addDefault("command-rules.home", "");
         addDefault("command-rules.back", "");
 
-        addDefault("maximum-x", 5000, "RandomTP", "The maximum X coordinate to go up to when selecting a random " +
-                "location.");
-        addDefault("maximum-z", 5000, "The maximum Z coordinate to go up to when selecting a random location.");
-        addDefault("minimum-x", -5000, "The minimum X coordinate to go down to when selecting a random location.");
-        addDefault("minimum-z", -5000, "The minimum Z coordinate to go down to when selecting a random location.");
+
+        addSection("RandomTP");
+        makeSectionLenient("x");
+        addDefault("x.default", "5000;-5000");
+        addExample("x.world_the_end", "10000;-10000");
+        addComment("x",
+                "Defines the range of X coordinates that players can teleport to.\n" +
+                        "Using a value for example 5000 would automatically set the minimum to -5000.\n" +
+                        "These are able to be defined for each world by name.\n" +
+                        "Split the values with a semicolon (;).\n" +
+                        "If a world is defined here but not in the z section, the x values will be reused for the z coords.\n"
+        );
+        addComment("z",
+                "Defines the range of z coordinates that players can teleport to.\n" +
+                        "Using a value for example 5000 would automatically set the minimum to -5000.\n" +
+                        "These are able to be defined for each world by name.\n" +
+                        "Split the values with a semicolon (;).\n" +
+                        "If a world is defined here but not in the x section, the z values will be reused for the x coords.\n"
+        );
+        makeSectionLenient("z");
+        addDefault("z.default", "5000;-5000");
+        addExample("z.world_the_end", "10000;-10000");
+        addDefault("maximum-x", 5000, "Deprecated\n # The maximum X coordinate to go up to when selecting a random location.");
+        addDefault("maximum-z", 5000, "Deprecated\n # The maximum Z coordinate to go up to when selecting a random location.");
+        addDefault("minimum-x", -5000, "Deprecated\n # The minimum X coordinate to go down to when selecting a random location.");
+        addDefault("minimum-z", -5000, "Deprecated\n # The minimum Z coordinate to go down to when selecting a random location.");
         addDefault("use-rapid-response", true, "Use the new rapid response system for RTP.\n" +
                 "This means valid locations are prepared before a user chooses to use /tpr or interact with a sign, " +
                 "meaning they are ready for use and can instantly TP a player.\n" +
@@ -354,6 +375,10 @@ public class NewConfig extends ATConfig {
         addDefault("use-plugin-borders", true, "Whether the plugin should use plugin world borders for managing /tpr " +
                 "boundaries.\n" +
                 "Currently supported plugins are WorldBorder and ChunkyBorder.");
+        addDefault("protect-claim-locations", true,
+                "If enabled checks if the player is in either an unclaimed area or that they have build permission in the area.\n" +
+                        "Supported plugins are Lands, WorldGuard, and GriefPrevention."
+        );
         addDefault("prepared-locations-limit", 3, "How many locations can be prepared per world when using AT's Rapid" +
                 " Response system.\n" +
                 "These are immediately prepared upon startup and when a world is loaded.");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -74,6 +74,8 @@ public class NewConfig extends ATConfig {
     public ConfigOption<Boolean> RAPID_RESPONSE;
     public ConfigOption<Boolean> USE_VANILLA_BORDER;
     public ConfigOption<Boolean> USE_PLUGIN_BORDERS;
+
+    public ConfigOption<Boolean> PREVENT_CLAIM_LOCATIONS;
     public ConfigOption<Integer> PREPARED_LOCATIONS_LIMIT;
     public ConfigOption<List<String>> IGNORE_WORLD_GENS;
     public ConfigOption<List<String>> AVOID_BLOCKS;

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -64,10 +64,13 @@ public class NewConfig extends ATConfig {
     public ConfigOption<ConfigSection> WORLD_RULES;
     public PerCommandOption<String> COMMAND_RULES;
 
-    public ConfigOption<Integer> MAXIMUM_X;
-    public ConfigOption<Integer> MAXIMUM_Z;
-    public ConfigOption<Integer> MINIMUM_X;
-    public ConfigOption<Integer> MINIMUM_Z;
+
+    public ConfigOption<ConfigSection> X;
+    public ConfigOption<ConfigSection> Z;
+    @Deprecated public ConfigOption<Integer> MAXIMUM_X;
+    @Deprecated public ConfigOption<Integer> MAXIMUM_Z;
+    @Deprecated public ConfigOption<Integer> MINIMUM_X;
+    @Deprecated public ConfigOption<Integer> MINIMUM_Z;
     public ConfigOption<Boolean> RAPID_RESPONSE;
     public ConfigOption<Boolean> USE_VANILLA_BORDER;
     public ConfigOption<Boolean> USE_PLUGIN_BORDERS;

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/NewConfig.java
@@ -74,8 +74,7 @@ public class NewConfig extends ATConfig {
     public ConfigOption<Boolean> RAPID_RESPONSE;
     public ConfigOption<Boolean> USE_VANILLA_BORDER;
     public ConfigOption<Boolean> USE_PLUGIN_BORDERS;
-
-    public ConfigOption<Boolean> PREVENT_CLAIM_LOCATIONS;
+    public ConfigOption<Boolean> PROTECT_CLAIM_LOCATIONS;
     public ConfigOption<Integer> PREPARED_LOCATIONS_LIMIT;
     public ConfigOption<List<String>> IGNORE_WORLD_GENS;
     public ConfigOption<List<String>> AVOID_BLOCKS;
@@ -653,6 +652,8 @@ public class NewConfig extends ATConfig {
         WORLD_RULES = new ConfigOption<>("world-rules");
         COMMAND_RULES = new PerCommandOption<>("command-rules", "");
 
+        X = new ConfigOption<>("x");
+        Z = new ConfigOption<>("z");
         MAXIMUM_X = new ConfigOption<>("maximum-x");
         MAXIMUM_Z = new ConfigOption<>("maximum-z");
         MINIMUM_X = new ConfigOption<>("minimum-x");
@@ -660,6 +661,7 @@ public class NewConfig extends ATConfig {
         RAPID_RESPONSE = new ConfigOption<>("use-rapid-response");
         USE_VANILLA_BORDER = new ConfigOption<>("use-vanilla-border");
         USE_PLUGIN_BORDERS = new ConfigOption<>("use-plugin-borders");
+        PROTECT_CLAIM_LOCATIONS = new ConfigOption<>("protect-claim-locations");
         PREPARED_LOCATIONS_LIMIT = new ConfigOption<>("prepared-locations-limit");
         IGNORE_WORLD_GENS = new ConfigOption<>("ignore-world-generators");
         AVOID_BLOCKS = new ConfigOption<>("avoid-blocks");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
@@ -10,6 +10,4 @@ public abstract class ClaimPlugin {
     public abstract boolean canUse(World world);
 
     public abstract boolean isClaimed(Location location);
-
-    public abstract boolean isPermitted(Location location, Player player);
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
@@ -3,7 +3,6 @@ package io.github.niestrat99.advancedteleport.hooks;
 
 import org.bukkit.World;
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 
 public abstract class ClaimPlugin {
 

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
@@ -1,0 +1,15 @@
+package io.github.niestrat99.advancedteleport.hooks;
+
+
+import org.bukkit.World;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public abstract class ClaimPlugin {
+
+    public abstract boolean canUse(World world);
+
+    public abstract boolean isClaimed(Location location);
+
+    public abstract boolean isPermitted(Location location, Player player);
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
@@ -17,7 +17,7 @@ public class GriefPreventionClaimHook extends ClaimPlugin {
 
     @Override
     public boolean canUse(World world) {
-        if (!NewConfig.get().PREVENT_CLAIM_LOCATIONS.get()) return false;
+        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get()) return false;
         if (!Bukkit.getPluginManager().isPluginEnabled("GriefPrevention")) return false;
         RegisteredServiceProvider<GriefPrevention> provider = Bukkit.getServer().getServicesManager().getRegistration(GriefPrevention.class);
         if (provider == null) return false;

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
@@ -1,0 +1,44 @@
+package io.github.niestrat99.advancedteleport.hooks.claims;
+
+import io.github.niestrat99.advancedteleport.config.NewConfig;
+import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.PlayerData;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public class GriefPreventionClaimHook extends ClaimPlugin {
+    private GriefPrevention griefPrevention;
+
+    @Override
+    public boolean canUse(World world) {
+        if (!NewConfig.get().PREVENT_CLAIM_LOCATIONS.get()) return false;
+        if (!Bukkit.getPluginManager().isPluginEnabled("GriefPrevention")) return false;
+        RegisteredServiceProvider<GriefPrevention> provider = Bukkit.getServer().getServicesManager().getRegistration(GriefPrevention.class);
+        if (provider == null) return false;
+        griefPrevention = provider.getProvider();
+        return griefPrevention.claimsEnabledForWorld(world);
+    }
+
+    @Override
+    public boolean isClaimed(Location location) {
+        return griefPrevention.dataStore.getClaimAt(location, false, null) != null;
+    }
+
+    @Override
+    public boolean isPermitted(
+            Location location,
+            Player player
+    ) {
+        PlayerData data = griefPrevention.dataStore.getPlayerData(player.getUniqueId());
+        Claim claim = griefPrevention.dataStore.getClaimAt(location, false, data.lastClaim);
+        if (claim == null) return true;
+        return claim.checkPermission(player, ClaimPermission.Build, null) == null;
+
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
@@ -2,14 +2,10 @@ package io.github.niestrat99.advancedteleport.hooks.claims;
 
 import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
-import me.ryanhamshire.GriefPrevention.Claim;
-import me.ryanhamshire.GriefPrevention.ClaimPermission;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
-import me.ryanhamshire.GriefPrevention.PlayerData;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
 public class GriefPreventionClaimHook extends ClaimPlugin {
@@ -17,8 +13,10 @@ public class GriefPreventionClaimHook extends ClaimPlugin {
 
     @Override
     public boolean canUse(World world) {
-        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get()) return false;
-        if (!Bukkit.getPluginManager().isPluginEnabled("GriefPrevention")) return false;
+        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get() ||
+            !Bukkit.getPluginManager().isPluginEnabled("GriefPrevention")
+        ) return false;
+
         RegisteredServiceProvider<GriefPrevention> provider = Bukkit.getServer().getServicesManager().getRegistration(GriefPrevention.class);
         if (provider == null) return false;
         griefPrevention = provider.getProvider();
@@ -28,17 +26,5 @@ public class GriefPreventionClaimHook extends ClaimPlugin {
     @Override
     public boolean isClaimed(Location location) {
         return griefPrevention.dataStore.getClaimAt(location, false, null) != null;
-    }
-
-    @Override
-    public boolean isPermitted(
-            Location location,
-            Player player
-    ) {
-        PlayerData data = griefPrevention.dataStore.getPlayerData(player.getUniqueId());
-        Claim claim = griefPrevention.dataStore.getClaimAt(location, false, data.lastClaim);
-        if (claim == null) return true;
-        return claim.checkPermission(player, ClaimPermission.Build, null) == null;
-
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
@@ -16,7 +16,7 @@ public class LandsClaimHook extends ClaimPlugin {
 
     @Override
     public boolean canUse(World world) {
-        if (!NewConfig.get().PREVENT_CLAIM_LOCATIONS.get()) return false;
+        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get()) return false;
         if (!Bukkit.getPluginManager().isPluginEnabled("Lands")) return false;
         if (lands == null) {
             lands = new LandsIntegration(CoreClass.getInstance());

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
@@ -1,0 +1,42 @@
+package io.github.niestrat99.advancedteleport.hooks.claims;
+
+import io.github.niestrat99.advancedteleport.CoreClass;
+import io.github.niestrat99.advancedteleport.config.NewConfig;
+import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
+import me.angeschossen.lands.api.integration.LandsIntegration;
+import me.angeschossen.lands.api.land.LandArea;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+
+public class LandsClaimHook extends ClaimPlugin {
+
+    private LandsIntegration lands;
+
+    @Override
+    public boolean canUse(World world) {
+        if (!NewConfig.get().PREVENT_CLAIM_LOCATIONS.get()) return false;
+        if (!Bukkit.getPluginManager().isPluginEnabled("Lands")) return false;
+        if (lands == null) {
+            lands = new LandsIntegration(CoreClass.getInstance());
+        }
+        return lands.getLandWorld(world) != null; // Returns true if the lands is active in the world.
+    }
+
+    @Override
+    public boolean isClaimed(Location location) {
+        return lands.isClaimed(location);
+    }
+
+    @Override
+    public boolean isPermitted(
+            Location location,
+            Player player
+    ) {
+        LandArea land = lands.getArea(location);
+        if (land == null) return true;
+        if (land.isTrusted(player.getUniqueId())) return true; // TODO: Check if this method includes the owner.
+        return land.getOwnerUID() == player.getUniqueId();
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
@@ -4,11 +4,9 @@ import io.github.niestrat99.advancedteleport.CoreClass;
 import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
 import me.angeschossen.lands.api.integration.LandsIntegration;
-import me.angeschossen.lands.api.land.LandArea;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
 
 public class LandsClaimHook extends ClaimPlugin {
 
@@ -16,8 +14,10 @@ public class LandsClaimHook extends ClaimPlugin {
 
     @Override
     public boolean canUse(World world) {
-        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get()) return false;
-        if (!Bukkit.getPluginManager().isPluginEnabled("Lands")) return false;
+        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get() ||
+            !Bukkit.getPluginManager().isPluginEnabled("Lands")
+        ) return false;
+
         if (lands == null) {
             lands = new LandsIntegration(CoreClass.getInstance());
         }
@@ -27,16 +27,5 @@ public class LandsClaimHook extends ClaimPlugin {
     @Override
     public boolean isClaimed(Location location) {
         return lands.isClaimed(location);
-    }
-
-    @Override
-    public boolean isPermitted(
-            Location location,
-            Player player
-    ) {
-        LandArea land = lands.getArea(location);
-        if (land == null) return true;
-        if (land.isTrusted(player.getUniqueId())) return true; // TODO: Check if this method includes the owner.
-        return land.getOwnerUID() == player.getUniqueId();
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
@@ -1,0 +1,49 @@
+package io.github.niestrat99.advancedteleport.hooks.claims;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import io.github.niestrat99.advancedteleport.config.NewConfig;
+import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public class WorldGuardClaimHook extends ClaimPlugin {
+
+    private RegionContainer container;
+
+    @Override
+    public boolean canUse(World world) {
+        if (!NewConfig.get().PREVENT_CLAIM_LOCATIONS.get()) return false;
+        if (!Bukkit.getPluginManager().isPluginEnabled("WorldGuard")) return false;
+        RegisteredServiceProvider<WorldGuard> provider = Bukkit.getServer().getServicesManager().getRegistration(WorldGuard.class);
+        if (provider == null) return false;
+        container = provider.getProvider().getPlatform().getRegionContainer();
+        return container.get(BukkitAdapter.adapt(world)) != null;
+    }
+
+    @Override
+    public boolean isClaimed(Location location) {
+        if (location.getWorld() == null) return false;
+        RegionQuery query = container.createQuery();
+        return query.getApplicableRegions(BukkitAdapter.adapt(location)).size() > 0;
+    }
+
+    @Override
+    public boolean isPermitted(
+            Location location,
+            Player player
+    ) {
+        if (location.getWorld() == null) return false;
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        RegionQuery query = container.createQuery();
+        return query.testState(BukkitAdapter.adapt(location), localPlayer, Flags.BUILD);
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
@@ -1,10 +1,7 @@
 package io.github.niestrat99.advancedteleport.hooks.claims;
 
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
-import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 import io.github.niestrat99.advancedteleport.config.NewConfig;
@@ -12,7 +9,6 @@ import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
 public class WorldGuardClaimHook extends ClaimPlugin {
@@ -21,8 +17,10 @@ public class WorldGuardClaimHook extends ClaimPlugin {
 
     @Override
     public boolean canUse(World world) {
-        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get()) return false;
-        if (!Bukkit.getPluginManager().isPluginEnabled("WorldGuard")) return false;
+        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get() ||
+            !Bukkit.getPluginManager().isPluginEnabled("WorldGuard")
+        ) return false;
+
         RegisteredServiceProvider<WorldGuard> provider = Bukkit.getServer().getServicesManager().getRegistration(WorldGuard.class);
         if (provider == null) return false;
         container = provider.getProvider().getPlatform().getRegionContainer();
@@ -34,16 +32,5 @@ public class WorldGuardClaimHook extends ClaimPlugin {
         if (location.getWorld() == null) return false;
         RegionQuery query = container.createQuery();
         return query.getApplicableRegions(BukkitAdapter.adapt(location)).size() > 0;
-    }
-
-    @Override
-    public boolean isPermitted(
-            Location location,
-            Player player
-    ) {
-        if (location.getWorld() == null) return false;
-        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
-        RegionQuery query = container.createQuery();
-        return query.testState(BukkitAdapter.adapt(location), localPlayer, Flags.BUILD);
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
@@ -21,7 +21,7 @@ public class WorldGuardClaimHook extends ClaimPlugin {
 
     @Override
     public boolean canUse(World world) {
-        if (!NewConfig.get().PREVENT_CLAIM_LOCATIONS.get()) return false;
+        if (!NewConfig.get().PROTECT_CLAIM_LOCATIONS.get()) return false;
         if (!Bukkit.getPluginManager().isPluginEnabled("WorldGuard")) return false;
         RegisteredServiceProvider<WorldGuard> provider = Bukkit.getServer().getServicesManager().getRegistration(WorldGuard.class);
         if (provider == null) return false;

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/PluginHookManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/PluginHookManager.java
@@ -64,6 +64,7 @@ public class PluginHookManager {
             map.put(name, clazz.getConstructor().newInstance());
         } catch (InstantiationException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             e.printStackTrace();
+        } catch (NoClassDefFoundError ignored) { // Why are you like this essentials?
         }
     }
 

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/PluginHookManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/PluginHookManager.java
@@ -1,20 +1,26 @@
 package io.github.niestrat99.advancedteleport.managers;
 
 import io.github.niestrat99.advancedteleport.hooks.BorderPlugin;
+import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
 import io.github.niestrat99.advancedteleport.hooks.ImportExportPlugin;
 import io.github.niestrat99.advancedteleport.hooks.borders.ChunkyBorderHook;
 import io.github.niestrat99.advancedteleport.hooks.borders.VanillaBorderHook;
 import io.github.niestrat99.advancedteleport.hooks.borders.WorldBorderHook;
+import io.github.niestrat99.advancedteleport.hooks.claims.GriefPreventionClaimHook;
+import io.github.niestrat99.advancedteleport.hooks.claims.LandsClaimHook;
+import io.github.niestrat99.advancedteleport.hooks.claims.WorldGuardClaimHook;
 import io.github.niestrat99.advancedteleport.hooks.imports.EssentialsHook;
-import io.github.niestrat99.advancedteleport.utilities.RandomCoords;
+import org.bukkit.Location;
 import org.bukkit.World;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 
 public class PluginHookManager {
 
     private HashMap<String, ImportExportPlugin> importPlugins;
     private HashMap<String, BorderPlugin> borderPlugins;
+    private HashMap<String, ClaimPlugin> claimPlugins;
     private static PluginHookManager instance;
 
     public PluginHookManager() {
@@ -25,12 +31,20 @@ public class PluginHookManager {
     public void init() {
         importPlugins = new HashMap<>();
         borderPlugins = new HashMap<>();
+        claimPlugins = new HashMap<>();
 
-        loadImportPlugin("essentials", EssentialsHook.class);
+        // Import plugins
+        loadPlugin(importPlugins, "essentials", EssentialsHook.class);
 
-        loadBorderPlugin("worldborder", WorldBorderHook.class);
-        loadBorderPlugin("chunkyborder", ChunkyBorderHook.class);
-        loadBorderPlugin("vanilla", VanillaBorderHook.class);
+        // World border Plugins
+        loadPlugin(borderPlugins, "worldborder", WorldBorderHook.class);
+        loadPlugin(borderPlugins, "chunkyborder", ChunkyBorderHook.class);
+        loadPlugin(borderPlugins, "vanilla", VanillaBorderHook.class);
+
+        // Claim Plugins
+        loadPlugin(claimPlugins, "worldguard", WorldGuardClaimHook.class);
+        loadPlugin(claimPlugins, "lands", LandsClaimHook.class);
+        loadPlugin(claimPlugins, "griefprevention", GriefPreventionClaimHook.class);
     }
 
     public static PluginHookManager get() {
@@ -45,34 +59,27 @@ public class PluginHookManager {
         return importPlugins.get(name);
     }
 
-    private void loadImportPlugin(String name, Class<? extends ImportExportPlugin> clazz) {
+    private <T> void loadPlugin(HashMap<String, T> map, String name, Class<? extends T> clazz) {
         try {
-            importPlugins.put(name, clazz.newInstance());
-        } catch (InstantiationException | IllegalAccessException e) {
+            map.put(name, clazz.getConstructor().newInstance());
+        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             e.printStackTrace();
-        } catch (NoClassDefFoundError ignored) {
-
-        }
-    }
-
-    private void loadBorderPlugin(String name, Class<? extends BorderPlugin> clazz) {
-        try {
-            borderPlugins.put(name, clazz.newInstance());
-        } catch (InstantiationException | IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (NoClassDefFoundError ignored) {
-
         }
     }
 
     public double[] getRandomCoords(World world) {
         for (BorderPlugin plugin : borderPlugins.values()) {
             if (!plugin.canUse(world)) continue;
-            return new double[]{
-                    RandomCoords.getRandomCoords(plugin.getMinX(world), plugin.getMaxX(world)),
-                    RandomCoords.getRandomCoords(plugin.getMinZ(world), plugin.getMaxZ(world))
-            };
+            return new double[]{plugin.getMinX(world), plugin.getMaxX(world), plugin.getMinZ(world), plugin.getMaxZ(world)};
         }
         return null;
+    }
+
+    public boolean isClaimed(Location location) {
+        for (ClaimPlugin plugin : claimPlugins.values()) {
+            if (!plugin.canUse(location.getWorld())) continue;
+            return plugin.isClaimed(location);
+        }
+        return false;
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/RTPManager.java
@@ -62,7 +62,10 @@ public class RTPManager {
         if (!PaperLib.isPaper()) return CompletableFuture.completedFuture(null);
         tries++;
         if (locQueue.get(world.getUID()) != null && locQueue.get(world.getUID()).size() > NewConfig.get().PREPARED_LOCATIONS_LIMIT.get()) {
-            return CompletableFuture.completedFuture(locQueue.get(world.getUID()).poll());
+            Location loc = locQueue.get(world.getUID()).poll();
+            if (!PluginHookManager.get().isClaimed(loc)) {
+                return CompletableFuture.completedFuture(loc);
+            }
         }
         Location location = RandomCoords.generateCoords(world);
         int[] coords = new int[]{location.getBlockX(), location.getBlockZ()};

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
@@ -65,4 +65,8 @@ public class RandomCoords {
         }
     }
 
+    public static void reload() {
+        coordCache.clear();
+    }
+
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
@@ -43,10 +43,10 @@ public class RandomCoords {
                     double[] coordsDouble = new double[4];
 
                     String[] xSplit = xStr != null ? xStr.split(";") : zStr.split(";"); // Use the Z coord if X isn't present for some reason
-                    setArray(coordsDouble, xSplit, 0, 1);
+                    setArray(coordsDouble, xSplit, 1, 0);
 
                     String[] zSplit = zStr != null ? zStr.split(";") : xStr.split(";"); // Use the X coord if Z isn't present for some reason
-                    setArray(coordsDouble, zSplit, 2, 3);
+                    setArray(coordsDouble, zSplit, 3, 2);
 
                     coordCache.put(world.getName(), coordsDouble);
                 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
@@ -40,15 +40,14 @@ public class RandomCoords {
                 String zStr = x.contains(world.getName()) ? z.getString(world.getName()) : z.getString("default");
 
                 if (xStr != null || zStr != null) {
-                    Integer[] coordsInt = new Integer[4];
+                    double[] coordsDouble = new double[4];
 
                     String[] xSplit = xStr != null ? xStr.split(";") : zStr.split(";"); // Use the Z coord if X isn't present for some reason
-                    setIntegers(coordsInt, xSplit, 0, 1);
+                    setArray(coordsDouble, xSplit, 0, 1);
 
                     String[] zSplit = zStr != null ? zStr.split(";") : xStr.split(";"); // Use the X coord if Z isn't present for some reason
-                    setIntegers(coordsInt, zSplit, 2, 3);
+                    setArray(coordsDouble, zSplit, 2, 3);
 
-                    double[] coordsDouble = new double[]{coordsInt[0], coordsInt[1], coordsInt[2], coordsInt[3]}; // Is there a better way of doing this?
                     coordCache.put(world.getName(), coordsDouble);
                 }
             }
@@ -63,7 +62,7 @@ public class RandomCoords {
         return getRandCoords(world, coords, y);
     }
 
-    private static void setIntegers(Integer[] array, String[] strArray, int c1, int c2) {
+    private static void setArray(double[] array, String[] strArray, int c1, int c2) {
         if (strArray.length > 1) {
             array[c1] = Integer.parseInt(strArray[0]);
             array[c2] = Integer.parseInt(strArray[1]);

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/RandomCoords.java
@@ -2,6 +2,7 @@ package io.github.niestrat99.advancedteleport.utilities;
 
 import io.github.niestrat99.advancedteleport.config.NewConfig;
 import io.github.niestrat99.advancedteleport.managers.PluginHookManager;
+import io.github.thatsmusic99.configurationmaster.api.ConfigSection;
 import org.bukkit.Location;
 import org.bukkit.World;
 
@@ -18,9 +19,30 @@ public class RandomCoords {
     public static Location generateCoords(World world) {
         double[] coords = PluginHookManager.get().getRandomCoords(world);
         if (coords == null) {
+            ConfigSection x = NewConfig.get().X.get();
+            ConfigSection z = NewConfig.get().Z.get();
+
+            String xStr = x.contains(world.getName()) ? x.getString(world.getName()) : x.getString("default");
+            String zStr = x.contains(world.getName()) ? z.getString(world.getName()) : z.getString("default");
+
+            Integer[] xInt = null;
+            Integer[] zInt = null;
+            if (xStr != null) {
+                String[] split = xStr.split(";");
+                xInt = split.length > 1
+                        ? new Integer[]{Integer.parseInt(split[0]), Integer.parseInt(split[1])}
+                        : new Integer[]{Integer.parseInt(split[0]), Integer.parseInt(String.format("-%s", split[0]))};
+            }
+            if (zStr != null) {
+                String[] split = zStr.split(";");
+                zInt = split.length > 1
+                        ? new Integer[]{Integer.parseInt(split[0]), Integer.parseInt(split[1])}
+                        : new Integer[]{Integer.parseInt(split[0]), Integer.parseInt(String.format("-%s", split[0]))};
+            }
+
             coords = new double[]{
-                    getRandomCoords(NewConfig.get().MINIMUM_X.get(), NewConfig.get().MAXIMUM_X.get()),
-                    getRandomCoords(NewConfig.get().MINIMUM_Z.get(), NewConfig.get().MAXIMUM_Z.get())
+                    getRandomCoords(xInt != null ? xInt[0] : NewConfig.get().MINIMUM_X.get(), xInt != null ? xInt[1] : NewConfig.get().MAXIMUM_X.get()),
+                    getRandomCoords(zInt != null ? zInt[0] : NewConfig.get().MINIMUM_Z.get(), zInt != null ? zInt[1] : NewConfig.get().MAXIMUM_Z.get())
             };
         }
         int y = world.getEnvironment() == World.Environment.NETHER ? 0 : 255;

--- a/AdvancedTeleport-Bukkit/src/main/resources/plugin.yml
+++ b/AdvancedTeleport-Bukkit/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${module.version}
 description: A rapidly growing teleportation plugin looking to break the boundaries of traditional teleport plugins.
 authors: [Niestrat99, Thatsmusic99]
 contributors: [SuspiciousLookingOwl (Github), animeavi (Github), MrEngMan, LucasMucGH (Github), jonas-t-s (Github)]
-softdepend: [Vault, Ultimate_Economy, ConfigurationMaster, WorldBorder, ChunkyBorder, floodgate]
+softdepend: [Vault, Ultimate_Economy, ConfigurationMaster, WorldBorder, ChunkyBorder, floodgate, lands, WorldGuard, GriefPrevention]
 loadbefore: [Essentials, EssentialsSpawn]
 api-version: 1.13
 

--- a/AdvancedTeleport-Bukkit/src/main/resources/plugin.yml
+++ b/AdvancedTeleport-Bukkit/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${module.version}
 description: A rapidly growing teleportation plugin looking to break the boundaries of traditional teleport plugins.
 authors: [Niestrat99, Thatsmusic99]
 contributors: [SuspiciousLookingOwl (Github), animeavi (Github), MrEngMan, LucasMucGH (Github), jonas-t-s (Github)]
-softdepend: [Vault, Ultimate_Economy, ConfigurationMaster, WorldBorder, ChunkyBorder, floodgate, lands, WorldGuard, GriefPrevention]
+softdepend: [Vault, Ultimate_Economy, ConfigurationMaster, WorldBorder, ChunkyBorder, floodgate, Lands, WorldGuard, GriefPrevention]
 loadbefore: [Essentials, EssentialsSpawn]
 api-version: 1.13
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -281,7 +281,8 @@ command-rules:
 # Defines the range of X coordinates that players can teleport to.
 # Using a value for example 5000 would automatically set the minimum to -5000.
 # These are able to be defined for each world by name.
-# Split the values with a semi colon (;).
+# Split the values with a semicolon (;).
+# If a world is defined here but not in the z section, the x values will be reused for the z coords.
 x:
   default: 5000;-5000
   world_the_end: 5000;-5000
@@ -289,7 +290,8 @@ x:
 # Defines the range of Z coordinates that players can teleport to.
 # Using a value for example 5000 would automatically set the minimum to -5000.
 # These are able to be defined for each world by name.
-# Split the values with a semi colon (;).
+# Split the values with a semicolon (;).
+# If a world is defined here but not in the z section, the x values will be reused for the z coords.
 z:
   default: 5000;-5000
   world_the_end: 10000;-10000

--- a/config/config.yml
+++ b/config/config.yml
@@ -278,9 +278,27 @@ command-rules:
 #  RandomTP  #
 ##############
 
+# Defines the range of X coordinates that players can teleport to.
+# Using a value for example 5000 would automatically set the minimum to -5000.
+# These are able to be defined for each world by name.
+# Split the values with a semi colon (;).
+x:
+  default: 5000;-5000
+  world_the_end: 5000;-5000
+
+# Defines the range of Z coordinates that players can teleport to.
+# Using a value for example 5000 would automatically set the minimum to -5000.
+# These are able to be defined for each world by name.
+# Split the values with a semi colon (;).
+z:
+  default: 5000;-5000
+  world_the_end: 10000;-10000
+
+# Deprecated
 # The maximum X coordinate to go up to when selecting a random location.
 maximum-x: 5000
 
+# Deprecated
 # The maximum Z coordinate to go up to when selecting a random location.
 maximum-z: 5000
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -313,6 +313,10 @@ minimum-z: -5000
 # When WorldBorder is installed, AT will check the border of each world instead rather than using the minimum and maximum coordinates.
 use-world-border: true
 
+# If enabled checks if the player is in either an unclaimed area or that they have build permission in the area.
+# Supported plugins are Lands, WorldGuard, and GriefPrevention.
+protect-claim-locations: true
+
 # Use the new rapid response system for RTP.
 # This means valid locations are prepared before a user chooses to use /tpr or interact with a sign, meaning they are ready for use and can instantly TP a player.
 # This feature allows you to use the "tpr" death option in the death management section further down.

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
             <id>mojang-authlib</id>
             <url>https://libraries.minecraft.net/</url>
         </repository>
+
+        <!-- World Guard Repo -->
+        <repository>
+            <id>sk89-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -201,6 +207,30 @@
             <groupId>org.geysermc.floodgate</groupId>
             <artifactId>api</artifactId>
             <version>2.1.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Dependency Lands -->
+        <dependency>
+            <groupId>com.github.angeschossen</groupId>
+            <artifactId>LandsAPI</artifactId>
+            <version>6.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Dependency Grief Prevention -->
+        <dependency>
+            <groupId>com.github.TechFortress</groupId>
+            <artifactId>GriefPrevention</artifactId>
+            <version>16.18</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Dependency World Guard -->
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.7</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR allows RTP min and max settings to be defined per world as well as using what I believe is a much nicer looking approach to the config settings of it.

Note this has not been tested yet and will be soon but I will update this PR once it has been tested.