### PR TITLE
feat: add invulnerability period

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATPlayer.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATPlayer.java
@@ -205,9 +205,7 @@ public class ATPlayer {
                                         teleportMsg,
                                         Placeholder.unparsed("home", event.getLocName()),
                                         Placeholder.unparsed("warp", event.getLocName()));
-                                PaymentManager.getInstance()
-                                        .withdraw(
-                                                command, player, event.getToLocation().getWorld());
+                                PaymentManager.getInstance().withdraw(command, player, event.getToLocation().getWorld());
                                 InvulnerabilityManager.createInvulnerability(player, getInvulnerability(command, event.getToLocation().getWorld()));
                                 ParticleManager.onPostTeleport(player, command);
 
@@ -218,7 +216,6 @@ public class ATPlayer {
                                     CooldownManager.addToCooldown(
                                             command, player, event.getToLocation().getWorld());
                                 }
-                                InvulnerabilityManager.createInvulnerability(player, getInvulnerability(command, event.getToLocation().getWorld()));
                             });
         }
     }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATPlayer.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATPlayer.java
@@ -12,10 +12,7 @@ import io.github.niestrat99.advancedteleport.api.events.players.PreviousLocation
 import io.github.niestrat99.advancedteleport.api.events.players.ToggleTeleportationEvent;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
-import io.github.niestrat99.advancedteleport.managers.CooldownManager;
-import io.github.niestrat99.advancedteleport.managers.MovementManager;
-import io.github.niestrat99.advancedteleport.managers.ParticleManager;
-import io.github.niestrat99.advancedteleport.managers.PluginHookManager;
+import io.github.niestrat99.advancedteleport.managers.*;
 import io.github.niestrat99.advancedteleport.payments.PaymentManager;
 import io.github.niestrat99.advancedteleport.sql.BlocklistManager;
 import io.github.niestrat99.advancedteleport.sql.HomeSQLManager;
@@ -208,7 +205,10 @@ public class ATPlayer {
                                         teleportMsg,
                                         Placeholder.unparsed("home", event.getLocName()),
                                         Placeholder.unparsed("warp", event.getLocName()));
-                                PaymentManager.getInstance().withdraw(command, player, event.getToLocation().getWorld());
+                                PaymentManager.getInstance()
+                                        .withdraw(
+                                                command, player, event.getToLocation().getWorld());
+                                InvulnerabilityManager.createInvulnerability(player, getInvulnerability(command, event.getToLocation().getWorld()));
                                 ParticleManager.onPostTeleport(player, command);
 
                                 if (MainConfig.get()
@@ -218,6 +218,7 @@ public class ATPlayer {
                                     CooldownManager.addToCooldown(
                                             command, player, event.getToLocation().getWorld());
                                 }
+                                InvulnerabilityManager.createInvulnerability(player, getInvulnerability(command, event.getToLocation().getWorld()));
                             });
         }
     }
@@ -607,7 +608,7 @@ public class ATPlayer {
 
                             if (home == null) return;
                             HomeSQLManager.get().removeHome(uuid, home.getName());
-                            
+
                 }, CoreClass.async);
     }
 
@@ -807,6 +808,17 @@ public class ATPlayer {
                 MainConfig.get().CUSTOM_COOLDOWNS.get(),
                 destinationWorld,
                 MainConfig.get().COOLDOWNS.valueOf(command).get());
+    }
+
+    @Range(from = 0, to = Integer.MAX_VALUE)
+    @Contract(pure = true)
+    public int getInvulnerability(@NotNull final String command, @NotNull final World destinationWorld) {
+        return determineValue("at.member.invulnerability",
+                command,
+                MainConfig.get().COMMAND_INVULNERABILITY_DURATIONS.valueOf(command).get(),
+                MainConfig.get().CUSTOM_INVULNERABILITY_DURATIONS.get(),
+                destinationWorld,
+                Math::max);
     }
 
     @Range(from = 0, to = Integer.MAX_VALUE)

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -144,6 +144,9 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Teleport.eventMovement",
                 "<prefix> <gray>Teleport has been cancelled due to movement.");
+        addDefault(
+                "Teleport.eventDamage",
+                "<prefix> <gray>Teleport has been cancelled due to damage being taken.");
         addDefault("Teleport.eventMovement_title.length", 60);
         addDefault("Teleport.eventMovement_title.fade-in", 0);
         addDefault("Teleport.eventMovement_title.fade-out", 10);

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
@@ -30,6 +30,7 @@ public final class MainConfig extends ATConfig {
     public ConfigOption<Integer> WARM_UP_TIMER_DURATION;
     public ConfigOption<Boolean> CANCEL_WARM_UP_ON_ROTATION;
     public ConfigOption<Boolean> CANCEL_WARM_UP_ON_MOVEMENT;
+    public ConfigOption<Boolean> CANCEL_WARM_UP_ON_DAMAGE;
     public ConfigOption<Boolean> CHECK_EXACT_COORDINATES;
     public PerCommandOption<Integer> WARM_UPS;
     public ConfigOption<ConfigSection> CUSTOM_WARM_UPS;
@@ -43,6 +44,10 @@ public final class MainConfig extends ATConfig {
     public ConfigOption<Object> COST_AMOUNT;
     public PerCommandOption<Object> COSTS;
     public ConfigOption<ConfigSection> CUSTOM_COSTS;
+    public ConfigOption<Integer> INVULNERABILITY_DURATION;
+    public ConfigOption<List<String>> INVULNERABILITY_DAMAGE_BLACKLIST;
+    public PerCommandOption<Integer> COMMAND_INVULNERABILITY_DURATIONS;
+    public ConfigOption<ConfigSection> CUSTOM_INVULNERABILITY_DURATIONS;
     public ConfigOption<Boolean> USE_PARTICLES;
     public PerCommandOption<String> TELEPORT_PARTICLES;
     public PerCommandOption<String> POST_TELEPORT_PARTICLES;
@@ -205,6 +210,12 @@ public final class MainConfig extends ATConfig {
                 "cancel-warm-up-on-movement",
                 true,
                 "Whether or not teleportation should be cancelled upon movement only.");
+        addDefault(
+                "cancel-warm-up-on-damage",
+                true,
+                "Whether or not teleportation should be cancelled when the player receives damage.\n" +
+                        "Best option to accompany the invulnerability system if your server has it enabled, so that " +
+                        "players can't cheese it. :thumbsup:");
         addDefault("check-exact-coordinates",
                 false,
                 "Whether the plugin should check for change in exact X, Y and Z vs. block X, Y, Z.\n" +
@@ -291,7 +302,7 @@ public final class MainConfig extends ATConfig {
                   vip-cooldown: 3
                 Giving a group, such as VIP, the permission at.member.cooldown.vip-cooldown will have a cooldown of 3.
                 The key (vip-cooldown) and group name (VIP) do not have to be different, this is just an example.
-                You can also add at.member.cooldown.3, but this is more efficient if you find permissions lag.To make it per-command, use at.member.cooldown.<command>.vip-cooldown. To make it per-world, use at.member.cooldown.<world>.vip-cooldown.
+                You can also add at.member.cooldown.3, but this is more efficient if you find permissions lag. To make it per-command, use at.member.cooldown.<command>.vip-cooldown. To make it per-world, use at.member.cooldown.<world>.vip-cooldown.
                 To combine the two, you can use at.member.cooldown.<command>.<world>.vip-cooldown.\
                 """);
 
@@ -332,6 +343,32 @@ public final class MainConfig extends ATConfig {
                   vip-cost: Essentials:100
                 Giving a group, such as VIP, the permission at.member.cost.vip-cost will have a cost of $100.
                 To make it per-command, add the permission at.member.cost.tpa.vip-cost (for tpa) instead.\
+                """);
+
+        addDefault("invulnerability-duration", 0, "Invulnerability", "How long the invulnerability period lasts in seconds.");
+        addDefault("damage-blacklist", new ArrayList<>(), "All damage causes that are not cancelled by invulnerability.\n" +
+                "The full list is accessible here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html");
+
+        addComment("per-command-invulnerability", "Command-specific invulnerability durations.");
+        addDefault("per-command-invulnerability.tpa", "default", "Invulnerability duration for /tpa.");
+        addDefault("per-command-invulnerability.tpahere", "default", "Invulnerability duration for /tpahere.");
+        addDefault("per-command-invulnerability.tpr", "default", "Invulnerability duration for /tpr, or /rtp.");
+        addDefault("per-command-invulnerability.warp", "default", "Invulnerability duration for /warp");
+        addDefault("per-command-invulnerability.spawn", "default", "Invulnerability duration for /spawn");
+        addDefault("per-command-invulnerability.home", "default", "Invulnerability duration for /home");
+        addDefault("per-command-invulnerability.back", "default", "Invulnerability duration for /back");
+
+        makeSectionLenient("custom-invulnerability-periods");
+        addComment(
+                "custom-invulnerability-periods",
+                """
+                Use this section to create custom invulnerability periods per-group.
+                Use the following format:
+                custom-invulnerability-periods:
+                  vip: 5
+                Giving a group, such as VIP, the permission at.member.invulnerability.vip will have an invulnerable period of 5 seconds.
+                To make it per-command, add the permission at.member.invulnerability.tpa.vip (for tpa) instead.\
+                You can also add at.member.invulnerability.5, but this is more efficient if you find permissions lag.
                 """);
 
         addDefault(
@@ -1025,6 +1062,7 @@ public final class MainConfig extends ATConfig {
         WARM_UP_TIMER_DURATION = new ConfigOption<>("warm-up-timer-duration");
         CANCEL_WARM_UP_ON_ROTATION = new ConfigOption<>("cancel-warm-up-on-rotation");
         CANCEL_WARM_UP_ON_MOVEMENT = new ConfigOption<>("cancel-warm-up-on-movement");
+        CANCEL_WARM_UP_ON_DAMAGE = new ConfigOption<>("cancel-warm-up-on-damage");
         CHECK_EXACT_COORDINATES = new ConfigOption<>("check-exact-coordinates");
         WARM_UPS = new PerCommandOption<>("per-command-warm-ups", "warm-up-timer-duration");
         CUSTOM_WARM_UPS = new ConfigOption<>("custom-warm-ups");
@@ -1055,6 +1093,11 @@ public final class MainConfig extends ATConfig {
         COST_AMOUNT = new ConfigOption<>("cost-amount");
         COSTS = new PerCommandOption<>("per-command-cost", "cost-amount");
         CUSTOM_COSTS = new ConfigOption<>("custom-costs");
+
+        INVULNERABILITY_DURATION = new ConfigOption<>("invulnerability-duration");
+        INVULNERABILITY_DAMAGE_BLACKLIST = new ConfigOption<>("damage-blacklist");
+        COMMAND_INVULNERABILITY_DURATIONS = new PerCommandOption<>("per-command-invulnerability", "invulnerability-duration");
+        CUSTOM_INVULNERABILITY_DURATIONS = new ConfigOption<>("custom-invulnerability-periods");
 
         USE_PARTICLES = new ConfigOption<>("use-particles");
         WAITING_PARTICLES =

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/InvulnerabilityManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/InvulnerabilityManager.java
@@ -1,0 +1,48 @@
+package io.github.niestrat99.advancedteleport.managers;
+
+import io.github.niestrat99.advancedteleport.CoreClass;
+import io.github.niestrat99.advancedteleport.config.MainConfig;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class InvulnerabilityManager {
+
+    public static void createInvulnerability(Player player, int duration) {
+        DamageListener damage = new DamageListener(player);
+
+        Bukkit.getScheduler().runTaskLater(CoreClass.getInstance(), task -> {
+            damage.destroy();
+        }, duration * 20L);
+    }
+
+    private static class DamageListener implements Listener {
+
+        private final @NotNull Player player;
+
+        public DamageListener(@NotNull Player player) {
+            this.player = player;
+            Bukkit.getPluginManager().registerEvents(this, CoreClass.getInstance());
+        }
+
+        @EventHandler
+        public void onDamage(EntityDamageEvent event) {
+
+            // If it's not this player, stop there
+            if (event.getEntity() != this.player) return;
+
+            // Check cause of damage in the damage list
+            if (MainConfig.get().INVULNERABILITY_DAMAGE_BLACKLIST.get().contains(event.getCause().name())) return;
+
+            event.setCancelled(true);
+        }
+
+        protected void destroy() {
+            HandlerList.unregisterAll(this);
+        }
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/MovementManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/MovementManager.java
@@ -13,6 +13,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.potion.PotionEffect;
@@ -39,6 +40,24 @@ public class MovementManager implements Listener {
             ParticleManager.removeParticles(event.getPlayer(), timer.command);
             movement.remove(uuid);
         }
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageEvent event) {
+
+        // Make sure it's a player and someone on a timer
+        if (!(event.getEntity() instanceof Player player)) return;
+        if (!movement.containsKey(player.getUniqueId())) return;
+
+        // Verify that the option is enabled and the player is not bypassing the option
+        if (MainConfig.get().CANCEL_WARM_UP_ON_DAMAGE.get() && !player.hasPermission("at.admin.bypass.damage")) return;
+
+        // Cancel the timer
+        final var timer = movement.get(player.getUniqueId());
+        timer.cancel();
+        CustomMessages.sendMessage(player, "Teleport.eventDamage");
+        ParticleManager.removeParticles(player, timer.command);
+        movement.remove(player.getUniqueId());
     }
 
     private static boolean willCancelTimer(PlayerMoveEvent event) {
@@ -152,6 +171,10 @@ public class MovementManager implements Listener {
                                     CustomMessages.sendMessage(teleportingPlayer, message, placeholders);
                                     PaymentManager.getInstance().withdraw(command, payingPlayer, location.getWorld());
                                     ParticleManager.onPostTeleport(teleportingPlayer, command);
+                                    InvulnerabilityManager.createInvulnerability(
+                                            teleportingPlayer,
+                                            ATPlayer.getPlayer(teleportingPlayer)
+                                                    .getInvulnerability(command, location.getWorld()));
 
                                     // If the cooldown is to be applied after only after a
                                     // teleport takes place,

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
@@ -7,6 +7,7 @@ import io.github.niestrat99.advancedteleport.api.events.ATTeleportEvent;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 import io.github.niestrat99.advancedteleport.managers.CooldownManager;
+import io.github.niestrat99.advancedteleport.managers.InvulnerabilityManager;
 import io.github.niestrat99.advancedteleport.managers.MovementManager;
 import io.github.niestrat99.advancedteleport.payments.PaymentManager;
 
@@ -71,6 +72,7 @@ public class AcceptRequest {
                 fromPlayer, toLocation, PlayerTeleportEvent.TeleportCause.COMMAND);
         CustomMessages.sendMessage(fromPlayer, "Teleport.eventTeleport");
         PaymentManager.getInstance().withdraw(type, payingPlayer, toLocation.getWorld());
+        InvulnerabilityManager.createInvulnerability(fromPlayer, atPlayer.getInvulnerability(type, event.getToLocation().getWorld()));
 
         // If the cooldown is to be applied after only after a teleport takes place, apply it now
         if (MainConfig.get().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("teleport")) {


### PR DESCRIPTION
Introduces new config options for handling invulnerability, including:
- Dynamic permissions and custom configuration like warm-ups and cooldowns (e.g. at.member.invulnerability.5 to be invulnerable for 5 seconds)
- A damage cause blacklist so certain damage types can be ignored easily