### PR TITLE
feat: warp aliases initial implementation

### DIFF
--- a/AdvancedTeleport-Bukkit/build.gradle.kts
+++ b/AdvancedTeleport-Bukkit/build.gradle.kts
@@ -465,6 +465,27 @@ bukkit {
             usage = "/tpofflinehere <Player>"
             aliases = listOf("tpofflh", "tpofflhere")
         }
+
+        register("setwarpalias") {
+            description = "Sets a warp's alias."
+            permission = "at.admin.setwarpalias"
+            usage = "/setwarpalias <Warp> <Alias>"
+            aliases = listOf("setwarpa")
+        }
+
+        register("removewarpalias") {
+            description = "Removes a warp's alias."
+            permission = "at.admin.removewarpalias"
+            usage = "/removewarpalias <Warp> <Alias>"
+            aliases = listOf("removewarpa", "remwarpa")
+        }
+
+        register("warpaliases") {
+            description = "Lists the warps an alias has, or the aliases that a warp has."
+            permission = "at.admin.warpaliases"
+            usage = "/warpaliases <warp|alias> <Warp|Alias>"
+            aliases = listOf("warpa")
+        }
     }
 
     permissions {

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/Warp.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/Warp.java
@@ -122,9 +122,7 @@ public class Warp implements NamedLocation {
                     this.updatedTimeFormatted = dateFormat.format(new Date(updatedTime));
 
                     return CompletableFuture.runAsync(
-                            () -> {
-                                WarpSQLManager.get().moveWarp(location, name);
-                            },
+                            () -> WarpSQLManager.get().moveWarp(location, name),
                             CoreClass.async);
                 });
     }
@@ -194,6 +192,12 @@ public class Warp implements NamedLocation {
 
                     // Removes the warp in cache.
                     NamedLocationManager.get().removeWarp(this);
+
+                    // If it has an alias too, remove that.
+                    for (String alias : AdvancedTeleportAPI.getWarpAliases().keySet()) {
+                        if (!AdvancedTeleportAPI.isAlias(alias, name)) continue;
+                        AdvancedTeleportAPI.removeWarpAlias(alias, this, sender);
+                    }
 
                     // Remove the warp in the database.
                     return CompletableFuture.runAsync(

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/events/warps/alias/WarpAliasAddEvent.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/events/warps/alias/WarpAliasAddEvent.java
@@ -1,0 +1,53 @@
+package io.github.niestrat99.advancedteleport.api.events.warps.alias;
+
+import io.github.niestrat99.advancedteleport.api.Warp;
+import io.github.niestrat99.advancedteleport.api.events.TrackableATEvent;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class WarpAliasAddEvent extends TrackableATEvent {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final @NotNull Warp warp;
+    private @NotNull String name;
+
+    public WarpAliasAddEvent(
+            @NotNull final String name,
+            @NotNull final Warp warp,
+            @Nullable final CommandSender sender
+    ) {
+        super(sender);
+
+        this.name = name;
+        this.warp = warp;
+    }
+
+    @Contract(pure = true)
+    public @NotNull Warp getWarp() {
+        return warp;
+    }
+
+    @Contract(pure = true)
+    public @NotNull String getName() {
+        return name;
+    }
+
+    @Contract(pure = true)
+    public void setName(@NotNull String name) {
+        this.name = name;
+    }
+
+    @Override
+    @Contract(pure = true)
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @Contract(pure = true)
+    public static @NotNull HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/events/warps/alias/WarpAliasRemoveEvent.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/events/warps/alias/WarpAliasRemoveEvent.java
@@ -1,0 +1,48 @@
+package io.github.niestrat99.advancedteleport.api.events.warps.alias;
+
+import io.github.niestrat99.advancedteleport.api.Warp;
+import io.github.niestrat99.advancedteleport.api.events.TrackableATEvent;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class WarpAliasRemoveEvent  extends TrackableATEvent {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final @NotNull Warp warp;
+    private final @NotNull String oldAlias;
+
+    public WarpAliasRemoveEvent(
+            @NotNull final String oldAlias,
+            @NotNull final Warp warp,
+            @Nullable final CommandSender sender
+    ) {
+        super(sender);
+
+        this.oldAlias = oldAlias;
+        this.warp = warp;
+    }
+
+    @Contract(pure = true)
+    public @NotNull Warp getWarp() {
+        return warp;
+    }
+
+    @Contract(pure = true)
+    public @NotNull String getOldAlias() {
+        return oldAlias;
+    }
+
+    @Override
+    @Contract(pure = true)
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @Contract(pure = true)
+    public static @NotNull HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/signs/WarpSign.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/signs/WarpSign.java
@@ -24,7 +24,7 @@ public class WarpSign extends ATSign {
     ) {
         Warp warp = AdvancedTeleportAPI.fetchWarp(sign.getLine(1), player, true);
         if (warp == null) return;
-        WarpCommand.warp(warp, player);
+        WarpCommand.warp(warp, warp.getName(), player);
     }
 
     @Override

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/signs/WarpSign.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/signs/WarpSign.java
@@ -2,6 +2,7 @@ package io.github.niestrat99.advancedteleport.api.signs;
 
 import io.github.niestrat99.advancedteleport.api.ATSign;
 import io.github.niestrat99.advancedteleport.api.AdvancedTeleportAPI;
+import io.github.niestrat99.advancedteleport.api.Warp;
 import io.github.niestrat99.advancedteleport.commands.warp.WarpCommand;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
@@ -17,9 +18,13 @@ public class WarpSign extends ATSign {
     }
 
     @Override
-    public void onInteract(@NotNull Sign sign, @NotNull Player player) {
-        if (!AdvancedTeleportAPI.getWarps().containsKey(sign.getLine(1))) return;
-        WarpCommand.warp(AdvancedTeleportAPI.getWarps().get(sign.getLine(1)), player, true);
+    public void onInteract(
+        @NotNull Sign sign,
+        @NotNull Player player
+    ) {
+        Warp warp = AdvancedTeleportAPI.fetchWarp(sign.getLine(1), player, true);
+        if (warp == null) return;
+        WarpCommand.warp(warp, player);
     }
 
     @Override

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/core/HelpCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/core/HelpCommand.java
@@ -3,6 +3,7 @@ package io.github.niestrat99.advancedteleport.commands.core;
 import io.github.niestrat99.advancedteleport.commands.SubATCommand;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.managers.CommandManager;
+import io.github.niestrat99.advancedteleport.utilities.MenuUtil;
 import io.github.niestrat99.advancedteleport.utilities.PagedLists;
 
 import net.kyori.adventure.text.Component;
@@ -166,25 +167,7 @@ public final class HelpCommand extends SubATCommand {
             return true;
         }
 
-        final var audience = CustomMessages.asAudience(sender);
-        final var helpHeader =
-                MiniMessage.miniMessage()
-                        .deserialize(
-                                "<aqua>・．<gray>━━━━━━━━━━━</gray> <dark_gray>❰</dark_gray> <bold>Advanced Teleport</bold> <gray><current_page>/<total_pages> <dark_gray>❱</dark_gray> <gray>━━━━━━━━━━━</gray>．・", // TODO: Allow customizing this in lang?
-                                TagResolver.builder()
-                                        .tag(
-                                                "current_page",
-                                                Tag.preProcessParsed(String.valueOf(page)))
-                                        .tag(
-                                                "total_pages",
-                                                Tag.preProcessParsed(
-                                                        String.valueOf(
-                                                                commandList.getTotalPages())))
-                                        .build());
-
-        audience.sendMessage(helpHeader);
-
-        for (final String command : commandList.getContentsInPage(page)) {
+        MenuUtil.sendMenu(sender, "help", commandList, command -> {
             var commandUsage = CustomMessages.getComponent("Usages." + command);
 
             if (sender.hasPermission("at.admin." + command)
@@ -194,20 +177,17 @@ public final class HelpCommand extends SubATCommand {
             }
 
             final var description = CustomMessages.getComponent("Descriptions." + command);
-            // TODO: Make configurable and use suppliers instead of computing above.
-            final var finalMessage =
-                    MiniMessage.miniMessage()
-                            .deserialize(
-                                    "<dark_gray>» <aqua><usage></aqua> ~ <gray><description>",
-                                    TagResolver.builder()
-                                            .tag("usage", Tag.selfClosingInserting(commandUsage))
-                                            .tag(
-                                                    "description",
-                                                    Tag.selfClosingInserting(description))
-                                            .build());
 
-            audience.sendMessage(finalMessage);
-        }
+            return MiniMessage.miniMessage()
+                    .deserialize(
+                            "<dark_gray>» <aqua><usage></aqua> ~ <gray><description>",
+                            TagResolver.builder()
+                                    .tag("usage", Tag.selfClosingInserting(commandUsage))
+                                    .tag(
+                                            "description",
+                                            Tag.selfClosingInserting(description))
+                                    .build());
+        }, page);
 
         return true;
     }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/WarpCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/WarpCommand.java
@@ -48,7 +48,7 @@ public final class WarpCommand extends AbstractWarpCommand implements TimedATCom
         // If the warp exists and the player isn't already teleporting, may as well warp them
         Warp warp = AdvancedTeleportAPI.fetchWarp(args[0], player, false);
         if (warp != null) {
-            warp(warp, player);
+            warp(warp, args[0], player);
         } else {
             CustomMessages.sendMessage(sender, "Error.noSuchWarp");
         }
@@ -78,8 +78,8 @@ public final class WarpCommand extends AbstractWarpCommand implements TimedATCom
         return results;
     }
 
-    public static void warp(Warp warp, Player player) {
-        ATTeleportEvent event = new ATTeleportEvent(player, warp.getLocation(), player.getLocation(), warp.getName(), ATTeleportEvent.TeleportType.WARP);
+    public static void warp(Warp warp, String name, Player player) {
+        ATTeleportEvent event = new ATTeleportEvent(player, warp.getLocation(), player.getLocation(), name, ATTeleportEvent.TeleportType.WARP);
         Bukkit.getPluginManager().callEvent(event);
         ATPlayer.getPlayer(player).teleport(event, "warp", "Teleport.teleportingToWarp");
     }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/alias/RemoveWarpAliasCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/alias/RemoveWarpAliasCommand.java
@@ -1,0 +1,88 @@
+package io.github.niestrat99.advancedteleport.commands.warp.alias;
+
+import io.github.niestrat99.advancedteleport.CoreClass;
+import io.github.niestrat99.advancedteleport.api.AdvancedTeleportAPI;
+import io.github.niestrat99.advancedteleport.api.Warp;
+import io.github.niestrat99.advancedteleport.commands.ATCommand;
+import io.github.niestrat99.advancedteleport.config.CustomMessages;
+import io.github.niestrat99.advancedteleport.config.MainConfig;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RemoveWarpAliasCommand extends ATCommand {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+
+        // Check the args
+        if (args.length < 1) {
+            CustomMessages.sendMessage(sender, "Error.noWarpInput");
+            return false;
+        }
+
+        if (args.length < 2) {
+            CustomMessages.sendMessage(sender, "Error.noWarpAliasInput");
+            return false;
+        }
+
+        // Get the alias and warp name
+        Warp warp = AdvancedTeleportAPI.getWarp(args[0]);
+        String alias = args[1];
+
+        // If the warp doesn't exist, stop there, since there's no warp to add an alias to
+        if (warp == null) {
+            CustomMessages.sendMessage(sender, "Error.noSuchWarp");
+            return true;
+        }
+
+        // See if it's already an alias
+        if (!AdvancedTeleportAPI.isAlias(alias, warp.getName())) {
+            CustomMessages.sendMessage(sender,
+                    "Error.notAnAlias",
+                    Placeholder.unparsed("alias", alias),
+                    Placeholder.unparsed("warp", warp.getName()));
+            return true;
+        }
+
+        // Add the alias
+        AdvancedTeleportAPI.removeWarpAlias(alias, warp, sender).whenCompleteAsync((result, err) ->
+                CustomMessages.failable(sender,
+                        "Info.addedWarpAlias",
+                        "Error.addWarpAliasFailed",
+                        err,
+                        Placeholder.unparsed("alias", alias),
+                        Placeholder.unparsed("warp", warp.getName())), CoreClass.sync);
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, @NotNull String[] args) {
+        List<String> results = new ArrayList<>();
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], AdvancedTeleportAPI.getWarps().keySet(), results);
+        }
+
+        if (args.length == 2) {
+            StringUtil.copyPartialMatches(args[1], AdvancedTeleportAPI.getWarpAliases(args[0]), results);
+        }
+
+        return results;
+    }
+
+    @Override
+    public boolean getRequiredFeature() {
+        return MainConfig.get().USE_WARPS.get();
+    }
+
+    @Override
+    public @NotNull String getPermission() {
+        return "at.admin.removewarpalias";
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/alias/SetWarpAliasCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/alias/SetWarpAliasCommand.java
@@ -1,0 +1,85 @@
+package io.github.niestrat99.advancedteleport.commands.warp.alias;
+
+import io.github.niestrat99.advancedteleport.CoreClass;
+import io.github.niestrat99.advancedteleport.api.AdvancedTeleportAPI;
+import io.github.niestrat99.advancedteleport.api.Warp;
+import io.github.niestrat99.advancedteleport.commands.ATCommand;
+import io.github.niestrat99.advancedteleport.config.CustomMessages;
+import io.github.niestrat99.advancedteleport.config.MainConfig;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SetWarpAliasCommand extends ATCommand {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+
+        // Check the args
+        if (args.length < 1) {
+            CustomMessages.sendMessage(sender, "Error.noWarpInput");
+            return false;
+        }
+
+        if (args.length < 2) {
+            CustomMessages.sendMessage(sender, "Error.noWarpAliasInput");
+            return false;
+        }
+
+        // Get the alias and warp name
+        Warp warp = AdvancedTeleportAPI.getWarp(args[0]);
+        String alias = args[1];
+
+        // If the warp doesn't exist, stop there, since there's no warp to add an alias to
+        if (warp == null) {
+            CustomMessages.sendMessage(sender, "Error.noSuchWarp");
+            return true;
+        }
+
+        // See if it's already an alias
+        if (AdvancedTeleportAPI.isAlias(alias, warp.getName())) {
+            CustomMessages.sendMessage(sender,
+                    "Error.alreadyAnAlias",
+                    Placeholder.unparsed("alias", alias),
+                    Placeholder.unparsed("warp", warp.getName()));
+            return true;
+        }
+
+        // Add the alias
+        AdvancedTeleportAPI.addWarpAlias(alias, warp, sender).whenCompleteAsync((result, err) ->
+            CustomMessages.failable(sender,
+                    "Info.addedWarpAlias",
+                    "Error.addWarpAliasFailed",
+                    err,
+                    Placeholder.unparsed("alias", alias),
+                    Placeholder.unparsed("warp", warp.getName())), CoreClass.sync);
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, @NotNull String[] args) {
+
+        List<String> results = new ArrayList<>();
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], AdvancedTeleportAPI.getWarps().keySet(), results);
+        }
+
+        return results;
+    }
+
+    @Override
+    public boolean getRequiredFeature() {
+        return MainConfig.get().USE_WARPS.get();
+    }
+
+    @Override
+    public @NotNull String getPermission() {
+        return "at.admin.setwarpalias";
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/alias/WarpAliasesCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/alias/WarpAliasesCommand.java
@@ -1,0 +1,125 @@
+package io.github.niestrat99.advancedteleport.commands.warp.alias;
+
+import io.github.niestrat99.advancedteleport.api.AdvancedTeleportAPI;
+import io.github.niestrat99.advancedteleport.commands.ATCommand;
+import io.github.niestrat99.advancedteleport.config.CustomMessages;
+import io.github.niestrat99.advancedteleport.config.MainConfig;
+import io.github.niestrat99.advancedteleport.utilities.MenuUtil;
+import io.github.niestrat99.advancedteleport.utilities.PagedLists;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class WarpAliasesCommand extends ATCommand {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+
+        // If there aren't enough arguments, let the sender know
+        if (args.length < 2) {
+            CustomMessages.sendMessage(sender, "Error.noAliasOrWarpInput");
+            return false;
+        }
+
+        String type = args[0].toLowerCase();
+        String name = args[1];
+        int page = 1;
+        if (args.length >= 3 && args[2].matches("^[0-9]+$")) {
+            page = Integer.parseInt(args[2]);
+        }
+
+        switch (type) {
+            case "warp" -> {
+
+                // Find all the aliases where the warp is in
+                List<String> aliases = new ArrayList<>();
+                for (String alias : AdvancedTeleportAPI.getWarpAliases().keySet()) {
+                    if (!AdvancedTeleportAPI.isAlias(alias, name)) continue;
+                    aliases.add(alias);
+                }
+
+                // If the aliases are empty, say this warp has no aliases
+                if (aliases.isEmpty()) {
+                    CustomMessages.sendMessage(sender,
+                            "Info.noWarpAliases",
+                            Placeholder.unparsed("warp", name));
+                    return true;
+                }
+
+                // Send the results
+                MenuUtil.sendMenu(sender,
+                        "warpAliases",
+                        new PagedLists<>(aliases, 8),
+                        warp -> MiniMessage.miniMessage().deserialize("<gray>> <aqua><warp>", Placeholder.unparsed("warp", warp)),
+                        page,
+                        Placeholder.unparsed("name", name),
+                        Placeholder.unparsed("type", type));
+                return true;
+            }
+            case "alias" -> {
+                List<String> results = AdvancedTeleportAPI.getWarpAliases(name);
+
+                // If there's no warps, then let the player know
+                if (results.isEmpty()) {
+                    CustomMessages.sendMessage(sender,
+                            "Info.noWarpsInAlias",
+                            Placeholder.unparsed("alias", name));
+                    return true;
+                }
+
+                // Send a menu
+                MenuUtil.sendMenu(sender,
+                        "warpAliases",
+                        new PagedLists<>(results, 8),
+                        warp -> MiniMessage.miniMessage().deserialize("<gray>> <aqua><warp>", Placeholder.unparsed("warp", warp)),
+                        page,
+                        Placeholder.unparsed("name", name),
+                        Placeholder.unparsed("type", type));
+                return true;
+            }
+            default -> CustomMessages.sendMessage(sender, "Error.noAliasOrWarpInput");
+        }
+
+        return false;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String s, @NotNull String[] args) {
+
+        // Store results
+        List<String> results = new ArrayList<>();
+
+        // Check the first argument
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], Arrays.asList("warp", "alias"), results);
+        }
+
+        // Check the second argument
+        if (args.length == 2) {
+            switch (args[0].toLowerCase()) {
+                case "warp" -> StringUtil.copyPartialMatches(args[1], AdvancedTeleportAPI.getWarps().keySet(), results);
+                case "alias" -> StringUtil.copyPartialMatches(args[1], AdvancedTeleportAPI.getWarpAliases().keySet(), results);
+            }
+        }
+
+        return results;
+    }
+
+    @Override
+    public boolean getRequiredFeature() {
+        return MainConfig.get().USE_WARPS.get();
+    }
+
+    @Override
+    public @NotNull String getPermission() {
+        return "at.admin.warpaliases";
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -247,6 +247,7 @@ public final class CustomMessages extends ATConfig {
                 "Error.homeAlreadySet",
                 "<prefix> <gray>You already have a home called <aqua><home></aqua>!");
         addDefault("Error.noWarpInput", "<prefix> <gray>You have to include the warp's name!");
+        addDefault("Error.noWarpAliasInput", "<prefix> <gray>You have to include an alias for the warp!");
         addDefault("Error.noSuchWarp", "<prefix> <gray>That warp doesn't exist!");
         addDefault(
                 "Error.warpAlreadySet",
@@ -393,6 +394,17 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Error.randomLocFailed",
                 "<prefix> <gray>Sorry, we couldn't find a location to teleport you to :(");
+        addDefault(
+                "Error.addWarpAliasFailed",
+                "<prefix> <gray>Failed to add the warp alias <aqua><alias></aqua> for <aqua><warp></aqua>!");
+        addDefault(
+                "Error.alreadyAnAlias",
+                "<prefix> <gray><aqua><alias></aqua> is already an alias for <aqua><warp></aqua>!");
+        addDefault("Error.notAnAlias",
+                "<prefix> <gray><aqua><alias></aqua> is not an alias for <aqua><warp></aqua>!");
+        addDefault(
+                "Error.noAliasOrWarpInput",
+                "<prefix> <gray>You have to specify whether you are checking a warp or alias, and specify that warp/alias!");
 
         makeSectionLenient("Info");
         addDefault("Info.tpOff", "<prefix> <gray>Successfully disabled teleport requests!");
@@ -597,6 +609,15 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Info.mirrorSpawnSame",
                 "<prefix> <gray>The spawns for <aqua><from></aqua> and <aqua><spawn></aqua> already to go the same place! Don't worry :)");
+        addDefault(
+                "Info.addedWarpAlias",
+                "<prefix> <gray>The warp alias <aqua><alias></aqua> now includes <aqua><warp></aqua>!");
+        addDefault(
+                "Info.noWarpAliases",
+                "<prefix> <gray>Warp <aqua><warp></aqua> does not have any aliases!");
+        addDefault(
+                "Info.noWarpsInAlias",
+                "<prefix> <gray>Alias <aqua><alias></aqua> does not redirect to any warps!");
 
         addDefault("Tooltip.homes", "<prefix> <gray>Teleports you to your home: <aqua><home>");
         addDefault("Tooltip.warps", "<prefix> <gray>Teleports you to warp: <aqua><warp>");
@@ -770,6 +791,13 @@ public final class CustomMessages extends ATConfig {
         addDefault("Usages-Admin.movehome", "/movehome <Home>|<Player> <Home>");
         addDefault("Usages-Admin.setmainhome", "/setmainhome <Home>|<Player> <Home>");
         addDefault("Usages-Admin.spawn", "/spawn <ID>");
+
+        addDefault(
+                "Menu.help",
+                "<aqua>・．<gray>━━━━━━━━━━━</gray> <dark_gray>❰</dark_gray> <bold>Advanced Teleport</bold> <gray><current_page>/<total_pages> <dark_gray>❱</dark_gray> <gray>━━━━━━━━━━━</gray>．・");
+        addDefault("Menu.warpAliases",
+                "<aqua>・．<gray>━━━━━━━━━━━</gray> <dark_gray>❰</dark_gray> <bold>Warp Aliases</bold>: <name> (<type>) <gray><current_page>/<total_pages> <dark_gray>❱</dark_gray> <gray>━━━━━━━━━━━</gray>．・");
+
 
         addFormsDefault(
                 "tpahere", "TPAHere Request", "Select a player to send a TPAHere request to.");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/CommandManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/CommandManager.java
@@ -9,6 +9,9 @@ import io.github.niestrat99.advancedteleport.commands.home.*;
 import io.github.niestrat99.advancedteleport.commands.spawn.*;
 import io.github.niestrat99.advancedteleport.commands.teleport.*;
 import io.github.niestrat99.advancedteleport.commands.warp.*;
+import io.github.niestrat99.advancedteleport.commands.warp.alias.RemoveWarpAliasCommand;
+import io.github.niestrat99.advancedteleport.commands.warp.alias.SetWarpAliasCommand;
+import io.github.niestrat99.advancedteleport.commands.warp.alias.WarpAliasesCommand;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 
 import org.bukkit.Bukkit;
@@ -64,6 +67,9 @@ public class CommandManager {
         register("delwarp", new DeleteWarpCommand());
         register("movewarp", new MoveWarpCommand());
         register("warps", new WarpsCommand());
+        register("warpaliases", new WarpAliasesCommand());
+        register("setwarpalias", new SetWarpAliasCommand());
+        register("removewarpalias", new RemoveWarpAliasCommand());
 
         register("spawn", new SpawnCommand());
         register("setspawn", new SetSpawn());

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/NamedLocationManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/NamedLocationManager.java
@@ -20,7 +20,9 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Used to manage the internal registration of warps and spawns during runtime. <br>
@@ -31,6 +33,7 @@ import java.util.HashMap;
 public class NamedLocationManager {
 
     @NotNull private final HashMap<String, Warp> warps;
+    @NotNull private final HashMap<String, List<String>> warpAliases;
     @NotNull private final HashMap<String, Spawn> spawns;
     @NotNull private final HashMap<String, Spawn> worldMirrors;
     @Nullable private Spawn mainSpawn;
@@ -40,6 +43,7 @@ public class NamedLocationManager {
         instance = this;
 
         this.warps = new HashMap<>();
+        this.warpAliases = new HashMap<>();
         this.spawns = new HashMap<>();
         this.worldMirrors = new HashMap<>();
 
@@ -100,6 +104,22 @@ public class NamedLocationManager {
 
     public ImmutableMap<String, Warp> getWarps() {
         return ImmutableMap.copyOf(this.warps);
+    }
+
+    public ImmutableMap<String, @NotNull List<String>> getWarpAliases() {
+        return ImmutableMap.copyOf(this.warpAliases);
+    }
+
+    public void addWarpAlias(@NotNull String name, @NotNull String warpName) {
+        List<String> aliases = this.warpAliases.getOrDefault(name, new ArrayList<>());
+        aliases.add(warpName);
+        this.warpAliases.put(name, aliases);
+    }
+
+    public void removeWarpAlias(@NotNull String name, @NotNull String warpName) {
+        List<String> aliases = this.warpAliases.getOrDefault(name, new ArrayList<>());
+        aliases.remove(warpName);
+        this.warpAliases.put(name, aliases);
     }
 
     @Contract(pure = true)

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/sql/MetadataSQLManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/sql/MetadataSQLManager.java
@@ -248,6 +248,21 @@ public class MetadataSQLManager extends SQLManager {
                         CoreClass.async);
     }
 
+    public CompletableFuture<Boolean> deleteWarpMetadata(String warpName, String key, String value) {
+        return WarpSQLManager.get()
+                .getWarpId(warpName)
+                .thenApplyAsync(
+                        id -> {
+                            try (Connection connection = implementConnection()) {
+                                if (id == -1) return false;
+                                return deleteMetadataSingle(connection, String.valueOf(id), "WARP", key, value);
+                            } catch (SQLException throwables) {
+                                throw new RuntimeException(throwables);
+                            }
+                        },
+                        CoreClass.async);
+    }
+
     public boolean deleteMetadata(Connection connection, String dataId, String type, String key)
             throws SQLException {
         PreparedStatement statement =
@@ -259,6 +274,22 @@ public class MetadataSQLManager extends SQLManager {
         statement.setString(1, dataId);
         statement.setString(2, type);
         statement.setString(3, key);
+        executeUpdate(statement);
+        return true;
+    }
+
+    public boolean deleteMetadataSingle(Connection connection, String dataId, String type, String key, String value)
+            throws SQLException {
+        PreparedStatement statement =
+                prepareStatement(
+                        connection,
+                        "DELETE FROM "
+                                + tablePrefix
+                                + "_metadata WHERE data_id = ? AND type = ? AND key = ? AND value = ?;");
+        statement.setString(1, dataId);
+        statement.setString(2, type);
+        statement.setString(3, key);
+        statement.setString(4, value);
         executeUpdate(statement);
         return true;
     }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/sql/WarpSQLManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/sql/WarpSQLManager.java
@@ -140,6 +140,22 @@ public class WarpSQLManager extends SQLManager {
                                         results.getLong("timestamp_created"),
                                         results.getLong("timestamp_updated")));
             }
+
+            // Close results and check aliases
+            results.close();
+            statement = prepareStatement(connection, "SELECT " + tablePrefix + "_warps.warp," +
+                    " " + tablePrefix + "_metadata.value " +
+                    "FROM " + tablePrefix + "_metadata " +
+                    "JOIN " + tablePrefix + "_warps " +
+                    "ON " + tablePrefix + "_warps.id = " + tablePrefix + "_metadata.data_id " +
+                    "AND " + tablePrefix + "_metadata.`key` = 'alias';");
+            results = executeQuery(statement);
+
+            // Register all aliases
+            while (results.next()) {
+                NamedLocationManager.get().addWarpAlias(results.getString("value"), results.getString("warp"));
+            }
+
         } catch (SQLException exception) {
             exception.printStackTrace();
         }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/MenuUtil.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/MenuUtil.java
@@ -1,0 +1,41 @@
+package io.github.niestrat99.advancedteleport.utilities;
+
+import io.github.niestrat99.advancedteleport.config.CustomMessages;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+public class MenuUtil {
+
+    public static <T> void sendMenu(@NotNull CommandSender sender,
+                                    @NotNull String menuKey,
+                                    @NotNull PagedLists<T> list,
+                                    @NotNull Function<T, Component> convert,
+                                    int page,
+                                    @NotNull TagResolver... extraHeaderPlaceholders) {
+
+        // Get the part of the list that we need
+        List<T> contents = list.getContentsInPage(page);
+
+        // Handle placeholders because Java is struggling
+        List<TagResolver> placeholders = new ArrayList<>(Arrays.asList(extraHeaderPlaceholders));
+        placeholders.add(Placeholder.unparsed("current_page", String.valueOf(page)));
+        placeholders.add(Placeholder.unparsed("total_pages", String.valueOf(list.getTotalPages())));
+
+        // Send the header
+        CustomMessages.sendMessage(sender,
+                "Menus." + menuKey,
+                placeholders.toArray(new TagResolver[0]));
+
+        // Go through each of the contents and send them
+        final var audience = CustomMessages.asAudience(sender);
+        contents.forEach(part -> audience.sendMessage(convert.apply(part)));
+    }
+}


### PR DESCRIPTION
Adds warp aliases, which work as a redirect to other warps. An alias can have multiple warps that it randomly selects, without needing the standard permission access to the backend warp. Instead, `at.member.warp.<alias>.<warp>` is checked.
- Adds `/setwarpalias <Warp> <Alias>` (at.admin.setwarpalias)
- Adds `/removewarpalias <Warp> <Alias>` (at.admin.removewarpalias)
- Adds `/warpaliases <warp|alias> <Warp|Alias>` (at.admin.warpaliases)
- Adds AdvancedTeleportAPI#fetchWarp, which fetches a warp depending on what a player has access to
- Adds respective API methods