### PR TITLE
feat: command coords implementation

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATPlayer.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATPlayer.java
@@ -473,7 +473,7 @@ public class ATPlayer {
     public @NotNull CompletableFuture<Void> addHome(
             @NotNull final String name,
             @NotNull final Location location,
-            @NotNull final Player creator) {
+            @NotNull final CommandSender creator) {
         return addHome(name, location, creator, true);
     }
 
@@ -489,7 +489,7 @@ public class ATPlayer {
     public @NotNull CompletableFuture<Void> addHome(
             @NotNull final String name,
             @NotNull final Location location,
-            @Nullable final Player creator,
+            @Nullable final CommandSender creator,
             final boolean async) {
 
         // If the home exists, move it instead

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/events/homes/HomeCreateEvent.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/events/homes/HomeCreateEvent.java
@@ -3,7 +3,7 @@ package io.github.niestrat99.advancedteleport.api.events.homes;
 import io.github.niestrat99.advancedteleport.api.events.TrackableATEvent;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -22,7 +22,7 @@ public final class HomeCreateEvent extends TrackableATEvent {
             @NotNull final OfflinePlayer player,
             @NotNull final String name,
             @NotNull final Location location,
-            @Nullable final Player creator)
+            @Nullable final CommandSender creator)
             throws IllegalArgumentException, IllegalStateException {
         super(creator);
 

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
@@ -191,7 +191,7 @@ public final class SetHomeCommand extends AbstractHomeCommand {
             }
 
             // Coordinates
-            if (sender instanceof Player player && args.length <= 8) {
+            if (sender instanceof Player player && args.length <= 8 && args.length > 2) {
                 final Location location = player.getLocation();
                 double[] coords = new double[]{
                         location.getBlockX() + 0.5,

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
@@ -1,24 +1,29 @@
 package io.github.niestrat99.advancedteleport.commands.home;
 
+import io.github.niestrat99.advancedteleport.CoreClass;
 import io.github.niestrat99.advancedteleport.api.ATFloodgatePlayer;
 import io.github.niestrat99.advancedteleport.api.ATPlayer;
 import io.github.niestrat99.advancedteleport.api.AdvancedTeleportAPI;
-import io.github.niestrat99.advancedteleport.commands.PlayerCommand;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public final class SetHomeCommand extends AbstractHomeCommand implements PlayerCommand {
+public final class SetHomeCommand extends AbstractHomeCommand {
 
     @Override
     public boolean onCommand(
@@ -27,6 +32,49 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
             @NotNull final String s,
             @NotNull final String[] args) {
         if (!canProceed(sender)) return true;
+
+        // If a location has been specified, use that
+        if (args.length > 5 && sender.hasPermission("at.admin.sethome.location")) {
+
+            // Set initial variables
+            final var targetName = args[0];
+            final var homeName = args[1];
+            final var worldName = args[2];
+
+            final var xStr = args[3];
+            final var yStr = args[4];
+            final var zStr = args[5];
+
+            final var yawStr = args.length > 6 ? args[6] : "0";
+            final var pitchStr = args.length > 7 ? args[7] : "0";
+
+            // Parse results, including world
+            final World world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                CustomMessages.sendMessage(sender, "Error.noSuchWorld");
+                return false;
+            }
+
+            try {
+                final var x = Double.parseDouble(xStr);
+                final var y = Double.parseDouble(yStr);
+                final var z = Double.parseDouble(zStr);
+                final var yaw = Float.parseFloat(yawStr);
+                final var pitch = Float.parseFloat(pitchStr);
+
+                Location location = new Location(world, x, y, z, yaw, pitch);
+
+                AdvancedTeleportAPI.getOfflinePlayer(targetName)
+                        .whenCompleteAsync((target, err) -> setHome(sender, target, location, homeName, targetName), CoreClass.sync);
+                return true;
+            } catch (NumberFormatException ex) {
+                CustomMessages.sendMessage(sender, "Error.invalidCoords");
+                return false;
+            }
+        } else if (!(sender instanceof Player)) {
+            CustomMessages.sendMessage(sender, "Error.notAPlayer");
+            return true;
+        }
 
         // Specify player variables
         final var player = (Player) sender;
@@ -61,7 +109,7 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
 
             // Get the player to be targeted.
             AdvancedTeleportAPI.getOfflinePlayer(args[0])
-                    .whenCompleteAsync((target, err) -> setHome(player, target, args[1], args[0]));
+                    .whenCompleteAsync((target, err) -> setHome(player, target, player.getLocation(), args[1], args[0]));
             return true;
         }
 
@@ -77,13 +125,13 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
     }
 
     private void setHome(Player sender, String name) {
-        setHome(sender, sender, name, sender.getName());
+        setHome(sender, sender, sender.getLocation(), name, sender.getName());
     }
 
     // Separated this into a separate method so that the code is easier to read.
     // Player player - the player which is having the home set.
     // String name - the name of the home.
-    private void setHome(Player sender, OfflinePlayer target, String homeName, String playerName) {
+    private void setHome(CommandSender sender, OfflinePlayer target, Location location, String homeName, String playerName) {
 
         ATPlayer atPlayer = ATPlayer.getPlayer(target);
 
@@ -96,7 +144,7 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
         }
 
         // Attempt to add the home.
-        atPlayer.addHome(homeName, sender.getLocation(), sender)
+        atPlayer.addHome(homeName, location, sender)
                 .whenComplete(
                         (ignored, err) ->
                                 CustomMessages.failableContextualPath(
@@ -125,6 +173,33 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
             @NotNull final Command command,
             @NotNull final String s,
             @NotNull final String[] args) {
+
+        List<String> results = new ArrayList<>();
+
+        // If the player can set locations, then check that
+        if (sender.hasPermission("at.admin.sethome.location")) {
+
+            // World
+            if (args.length == 3) {
+                StringUtil.copyPartialMatches(args[2], Bukkit.getWorlds().stream().map(World::getName).toList(), results);
+                return results;
+            }
+
+            // Coordinates
+            if (sender instanceof Player player && args.length <= 8) {
+                final Location location = player.getLocation();
+                double[] coords = new double[]{
+                        location.getBlockX() + 0.5,
+                        location.getBlockY(),
+                        location.getBlockZ() + 0.5,
+                        location.getYaw(),
+                        location.getPitch()
+                };
+
+                StringUtil.copyPartialMatches(args[args.length - 1], Collections.singleton(String.valueOf(coords[args.length - 3])), results);
+                return results;
+            }
+        }
         return new ArrayList<>();
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -393,6 +393,9 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Error.randomLocFailed",
                 "<prefix> <gray>Sorry, we couldn't find a location to teleport you to :(");
+        addDefault(
+                "Error.invalidCoords",
+                "<prefix> <gray>You have to specify valid coordinates to set a player's home via location!");
 
         makeSectionLenient("Info");
         addDefault("Info.tpOff", "<prefix> <gray>Successfully disabled teleport requests!");


### PR DESCRIPTION
Allows administrators with the permission `at.admin.sethome.location` to set homes using coordinates. Console is also able to use this.

Command usage: `/sethome <User> <Home> <World> <X> <Y> <Z> [Yaw] [Pitch]`

Would fancy getting /setwarp and /setspawn on board before merging this