### PR TITLE
feat: FactionsUUID integration

### DIFF
--- a/AdvancedTeleport-Bukkit/build.gradle.kts
+++ b/AdvancedTeleport-Bukkit/build.gradle.kts
@@ -84,6 +84,10 @@ repositories {
         name = "PlayerParticles"
         content { includeGroup("dev.esophose") }
     }
+
+    maven("https://ci.ender.zone/plugin/repository/everything/") {
+        name = "FactionsUUID"
+    }
 }
 
 dependencies {
@@ -119,6 +123,7 @@ dependencies {
     compileOnly(libs.playerparticles)
     compileOnly(libs.worldguard)
     compileOnly(libs.squaremap)
+    compileOnly(libs.factionsuuid)
     compileOnly(libs.dynmap) {
         artifact { // Uses wrong jar if not specified
             name = "dynmap-api"
@@ -248,7 +253,7 @@ bukkit {
     main = "io.github.niestrat99.advancedteleport.CoreClass"
     load = BukkitPluginDescription.PluginLoadOrder.POSTWORLD
 
-    softDepend = listOf("Vault", "Ultimate_Economy", "ConfigurationMaster", "WorldBorder", "ChunkyBorder", "floodgate", "Lands", "WorldGuard", "GriefProtection", "dynmap", "squaremap", "PlayerParticles")
+    softDepend = listOf("Vault", "Ultimate_Economy", "ConfigurationMaster", "WorldBorder", "ChunkyBorder", "floodgate", "Lands", "WorldGuard", "GriefProtection", "dynmap", "squaremap", "PlayerParticles", "Factions")
     loadBefore = listOf("Essentials", "EssentialsSpawn")
 
     commands {

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomeCommand.java
@@ -34,77 +34,79 @@ public final class HomeCommand extends AbstractHomeCommand implements TimedATCom
 
         // If more than one argument has been specified and the player is an admin...
         if (args.length > 1 && sender.hasPermission(getAdminPermission())) {
-            ATPlayer.getPlayerFuture(args[0])
-                    .thenAccept(
-                            target ->
-                                    target.getHomesAsync()
-                                            .thenAcceptAsync(
-                                                    homesOther -> {
+            ATPlayer.getPlayerFuture(args[0]).whenCompleteAsync((target, err) -> {
 
-                                                        // If the home has been set with the
-                                                        // specific name, use that
-                                                        Home home = homesOther.get(args[1]);
-                                                        if (home != null) {
-                                                            ATPlayer.teleportWithOptions(
-                                                                    player,
-                                                                    home.getLocation(),
-                                                                    PlayerTeleportEvent
-                                                                            .TeleportCause.COMMAND);
-                                                            CustomMessages.sendMessage(
-                                                                    sender,
-                                                                    "Teleport.teleportingToHomeOther",
-                                                                    Placeholder.unparsed(
-                                                                            "player", args[0]),
-                                                                    Placeholder.unparsed(
-                                                                            "home", args[1]));
-                                                            return;
-                                                        }
+                if (err != null) {
+                    err.printStackTrace();
+                    return;
+                }
 
-                                                        // If we're using a bed, try getting the bed
-                                                        // spawn
-                                                        if (args[1].equalsIgnoreCase("bed")
-                                                                && MainConfig.get()
-                                                                        .ADD_BED_TO_HOMES
-                                                                        .get()) {
-                                                            home = target.getBedSpawn();
-                                                            if (home != null) {
-                                                                ATPlayer.teleportWithOptions(
-                                                                        player,
-                                                                        home.getLocation(),
-                                                                        PlayerTeleportEvent
-                                                                                .TeleportCause
-                                                                                .COMMAND);
-                                                                CustomMessages.sendMessage(
-                                                                        sender,
-                                                                        "Teleport.teleportingToHomeOther",
-                                                                        Placeholder.unparsed(
-                                                                                "player", args[0]),
-                                                                        Placeholder.unparsed(
-                                                                                "home", args[1]));
-                                                                return;
-                                                            }
-                                                        }
+                target.getHomesAsync().whenCompleteAsync((homesOther, err2) -> {
 
-                                                        // If we're requesting a list, just throw it
-                                                        if (args[1].equalsIgnoreCase("list")) {
-                                                            Bukkit.getScheduler()
-                                                                    .runTask(
-                                                                            CoreClass.getInstance(),
-                                                                            () ->
-                                                                                    Bukkit
-                                                                                            .dispatchCommand(
-                                                                                                    sender,
-                                                                                                    "advancedteleport:homes "
-                                                                                                            + args[
-                                                                                                                    0]));
-                                                            return;
-                                                        }
+                    if (err2 != null) {
+                        err2.printStackTrace();
+                        return;
+                    }
 
-                                                        // Tell the player there is no such home
-                                                        CustomMessages.sendMessage(
-                                                                sender, "Error.noSuchHome");
-                                                    },
-                                                    CoreClass.sync));
+                    // If the home has been set with the specific name, use that
+                    Home home = homesOther.get(args[1]);
+                    if (home != null) {
+                        ATPlayer.teleportWithOptions(
+                                player,
+                                home.getLocation(),
+                                PlayerTeleportEvent
+                                        .TeleportCause.COMMAND);
+                        CustomMessages.sendMessage(
+                                sender,
+                                "Teleport.teleportingToHomeOther",
+                                Placeholder.unparsed(
+                                        "player", args[0]),
+                                Placeholder.unparsed(
+                                        "home", args[1]));
+                        return;
+                    }
+
+                    // If we're using a bed, try getting the bed spawn
+                    if (args[1].equalsIgnoreCase("bed")
+                            && MainConfig.get()
+                            .ADD_BED_TO_HOMES
+                            .get()) {
+                        home = target.getBedSpawn();
+                        if (home != null) {
+                            ATPlayer.teleportWithOptions(
+                                    player,
+                                    home.getLocation(),
+                                    PlayerTeleportEvent
+                                            .TeleportCause
+                                            .COMMAND);
+                            CustomMessages.sendMessage(
+                                    sender,
+                                    "Teleport.teleportingToHomeOther",
+                                    Placeholder.unparsed(
+                                            "player", args[0]),
+                                    Placeholder.unparsed(
+                                            "home", args[1]));
+                            return;
+                        }
+                    }
+
+                    // If we're requesting a list, just throw it
+                    if (args[1].equalsIgnoreCase("list")) {
+                        Bukkit.getScheduler()
+                                .runTask(
+                                        CoreClass.getInstance(),
+                                        () ->
+                                                Bukkit
+                                                        .dispatchCommand(
+                                                                sender,
+                                                                "advancedteleport:homes " + args[0]));
+                        return;
+                    }
+
+                    // Tell the player there is no such home
+                            CustomMessages.sendMessage(sender, "Error.noSuchHome");
+                }, CoreClass.sync);
+            }, CoreClass.sync);
 
             return true;
         }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
@@ -7,6 +7,7 @@ import io.github.niestrat99.advancedteleport.commands.PlayerCommand;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 
+import io.github.niestrat99.advancedteleport.managers.PluginHookManager;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 
 import org.bukkit.OfflinePlayer;
@@ -32,6 +33,13 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
         final var player = (Player) sender;
         final var atPlayer = ATPlayer.getPlayer(player);
 
+        // If the player can't set a home here, tell them
+        if (!PluginHookManager.get().canAccess(player, player.getLocation())
+                && !player.hasPermission("at.admin.sethome.bypass.location")) {
+            CustomMessages.sendMessage(sender, "Error.cantSetHomeLoc");
+            return true;
+        }
+
         // If no arguments have been specified, just use the information from that
         if (args.length == 0) {
 
@@ -39,7 +47,7 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
             final int limit = atPlayer.getHomesLimit();
 
             // If the homes list is empty, set a new home called "home".
-            if (atPlayer.getHomes().size() == 0 && (limit > 0 || limit == -1)) {
+            if (atPlayer.getHomes().isEmpty() && (limit > 0 || limit == -1)) {
                 setHome(player, "home");
                 return true;
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/SetWarpCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/SetWarpCommand.java
@@ -7,6 +7,7 @@ import io.github.niestrat99.advancedteleport.commands.PlayerCommand;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 
+import io.github.niestrat99.advancedteleport.managers.PluginHookManager;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 
 import org.bukkit.Location;
@@ -29,6 +30,13 @@ public final class SetWarpCommand extends AbstractWarpCommand implements PlayerC
         if (!canProceed(sender)) return true;
 
         Player player = (Player) sender;
+
+        // If the player can't set a home here, tell them
+        if (!PluginHookManager.get().canAccess(player, player.getLocation())
+                && !player.hasPermission("at.admin.setwarp.bypass.location")) {
+            CustomMessages.sendMessage(sender, "Error.cantSetWarpLoc");
+            return true;
+        }
 
         if (args.length == 0) {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -275,6 +275,9 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Error.cantTPToWorldLim",
                 "<prefix> <gray>You can't teleport to <aqua><world></aqua>!");
+        addDefault(
+                "Error.cantTPToLoc",
+                "<prefix> <gray>You can't teleport to that location!");
         addDefault("Error.tooFewArguments", "<prefix> <gray>Too few arguments!");
         addDefault("Error.invalidArgs", "<prefix> <gray>Invalid arguments!");
         addDefault(

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -246,11 +246,15 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Error.homeAlreadySet",
                 "<prefix> <gray>You already have a home called <aqua><home></aqua>!");
+        addDefault("Error.cantSetHomeLoc",
+                "<prefix> <gray>You can't set a home here!");
         addDefault("Error.noWarpInput", "<prefix> <gray>You have to include the warp's name!");
         addDefault("Error.noSuchWarp", "<prefix> <gray>That warp doesn't exist!");
         addDefault(
                 "Error.warpAlreadySet",
                 "<prefix> <gray>There is already a warp called <aqua><warp></aqua>!");
+        addDefault("Error.cantSetWarpLoc",
+                "<prefix> <gray>You can't set a warp here!");
         addDefault("Error.noSuchWorld", "<prefix> <gray>That world doesn't exist!");
         addDefault("Error.worldUnloaded",
                 "<prefix> <gray>Sorry, the destination world either doesn't exist or isn't loaded. Please tell a server admin!");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/ClaimPlugin.java
@@ -4,6 +4,7 @@ import io.github.niestrat99.advancedteleport.config.MainConfig;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -27,4 +28,6 @@ public abstract class ClaimPlugin<P extends Plugin, R> extends PluginHook<P, R> 
     }
 
     public abstract boolean isClaimed(@NotNull final Location location);
+
+    public abstract boolean canAccess(final @NotNull Player player, final @NotNull Location location);
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/PluginHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/PluginHook.java
@@ -1,5 +1,6 @@
 package io.github.niestrat99.advancedteleport.hooks;
 
+import io.github.niestrat99.advancedteleport.CoreClass;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/FactionsUUIDClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/FactionsUUIDClaimHook.java
@@ -29,7 +29,7 @@ public class FactionsUUIDClaimHook extends ClaimPlugin<Plugin, FactionsPlugin> {
         final FLocation fLocation = new FLocation(location);
         final Faction faction = Board.getInstance().getFactionAt(fLocation);
         if (faction == null) return true;
-        if (faction.isWilderness()) return true;
+        if (faction.isWilderness() || faction.isSafeZone() || faction.isWarZone()) return true;
 
         // Check if the player has access
         final FPlayer fPlayer = FPlayers.getInstance().getByPlayer(player);

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/FactionsUUIDClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/FactionsUUIDClaimHook.java
@@ -1,0 +1,38 @@
+package io.github.niestrat99.advancedteleport.hooks.claims;
+
+import com.massivecraft.factions.*;
+import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+public class FactionsUUIDClaimHook extends ClaimPlugin<Plugin, FactionsPlugin> {
+
+    public FactionsUUIDClaimHook() {
+        super("Factions", FactionsPlugin.class);
+    }
+
+    @Override
+    public boolean isClaimed(@NotNull Location location) {
+
+        // Check if there's a faction
+        final FLocation fLocation = new FLocation(location);
+        final Faction faction = Board.getInstance().getFactionAt(fLocation);
+        return faction != null;
+    }
+
+    @Override
+    public boolean canAccess(@NotNull Player player, @NotNull Location location) {
+
+        // Check if there's a faction
+        final FLocation fLocation = new FLocation(location);
+        final Faction faction = Board.getInstance().getFactionAt(fLocation);
+        if (faction == null) return true;
+        if (faction.isWilderness()) return true;
+
+        // Check if the player has access
+        final FPlayer fPlayer = FPlayers.getInstance().getByPlayer(player);
+        return faction.getFPlayers().contains(fPlayer);
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/FactionsUUIDClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/FactionsUUIDClaimHook.java
@@ -1,6 +1,7 @@
 package io.github.niestrat99.advancedteleport.hooks.claims;
 
 import com.massivecraft.factions.*;
+import com.massivecraft.factions.perms.Relation;
 import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -33,6 +34,8 @@ public class FactionsUUIDClaimHook extends ClaimPlugin<Plugin, FactionsPlugin> {
 
         // Check if the player has access
         final FPlayer fPlayer = FPlayers.getInstance().getByPlayer(player);
-        return faction.getFPlayers().contains(fPlayer);
+        final Relation relation = faction.getRelationTo(fPlayer);
+
+        return relation.isMember() || relation.isAlly() || relation.isTruce();
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/GriefPreventionClaimHook.java
@@ -2,10 +2,12 @@ package io.github.niestrat99.advancedteleport.hooks.claims;
 
 import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
 
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -37,5 +39,14 @@ public final class GriefPreventionClaimHook extends ClaimPlugin<Plugin, GriefPre
     @Contract(pure = true)
     public boolean isClaimed(@NotNull final Location location) {
         return griefPrevention.dataStore.getClaimAt(location, false, null) != null;
+    }
+
+    @Override
+    public boolean canAccess(@NotNull Player player, @NotNull Location location) {
+        final var claim = griefPrevention.dataStore.getClaimAt(location, false, null);
+        if (claim == null) return true;
+        final var result = claim.checkPermission(player, ClaimPermission.Access, null);
+        if (result == null) return true;
+        return result.get() == null;
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/LandsClaimHook.java
@@ -7,6 +7,7 @@ import me.angeschossen.lands.api.LandsIntegration;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -40,5 +41,14 @@ public final class LandsClaimHook
     public boolean isClaimed(@NotNull final Location location) {
         final var chunk = location.getChunk();
         return lands.getLandByChunk(chunk.getWorld(), chunk.getX(), chunk.getZ()) != null;
+    }
+
+    @Override
+    public boolean canAccess(@NotNull Player player, @NotNull Location location) {
+        final var chunk = location.getChunk();
+        final var land = lands.getLandByChunk(chunk.getWorld(), chunk.getX(), chunk.getZ());
+        if (land == null) return true;
+
+        return land.isTrusted(player.getUniqueId());
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/hooks/claims/WorldGuardClaimHook.java
@@ -2,6 +2,8 @@ package io.github.niestrat99.advancedteleport.hooks.claims;
 
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 
@@ -9,6 +11,7 @@ import io.github.niestrat99.advancedteleport.hooks.ClaimPlugin;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -28,14 +31,8 @@ public final class WorldGuardClaimHook extends ClaimPlugin<Plugin, WorldGuard> {
         // Ensures claim avoidance is enabled
         if (!super.canUse(world)) return false;
 
-        // Ensures the container is available in the world.
-        return this.provider()
-                .map(
-                        provider -> {
-                            container = provider.getPlatform().getRegionContainer();
-                            return container.get(BukkitAdapter.adapt(world)) != null;
-                        })
-                .orElse(false);
+        container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        return container.get(BukkitAdapter.adapt(world)) != null;
     }
 
     @Override
@@ -43,5 +40,11 @@ public final class WorldGuardClaimHook extends ClaimPlugin<Plugin, WorldGuard> {
     public boolean isClaimed(@NotNull final Location location) {
         RegionQuery query = container.createQuery();
         return query.getApplicableRegions(BukkitAdapter.adapt(location)).size() > 0;
+    }
+
+    @Override
+    public boolean canAccess(@NotNull Player player, @NotNull Location location) {
+        RegionQuery query = container.createQuery();
+        return query.testState(BukkitAdapter.adapt(location), WorldGuardPlugin.inst().wrapPlayer(player), Flags.ENTRY);
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/PluginHookManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/PluginHookManager.java
@@ -10,6 +10,7 @@ import io.github.niestrat99.advancedteleport.hooks.PluginHook;
 import io.github.niestrat99.advancedteleport.hooks.borders.ChunkyBorderHook;
 import io.github.niestrat99.advancedteleport.hooks.borders.VanillaBorderHook;
 import io.github.niestrat99.advancedteleport.hooks.borders.WorldBorderHook;
+import io.github.niestrat99.advancedteleport.hooks.claims.FactionsUUIDClaimHook;
 import io.github.niestrat99.advancedteleport.hooks.claims.GriefPreventionClaimHook;
 import io.github.niestrat99.advancedteleport.hooks.claims.LandsClaimHook;
 import io.github.niestrat99.advancedteleport.hooks.claims.WorldGuardClaimHook;
@@ -23,6 +24,7 @@ import io.github.niestrat99.advancedteleport.sql.WarpSQLManager;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -62,6 +64,7 @@ public final class PluginHookManager {
         loadPlugin("worldguard", WorldGuardClaimHook.class);
         loadPlugin("lands", LandsClaimHook.class);
         loadPlugin("griefprevention", GriefPreventionClaimHook.class);
+        loadPlugin("factionsuuid", FactionsUUIDClaimHook.class);
 
         loadPlugin("squaremap", SquaremapHook.class);
         loadPlugin("dynmap", DynmapHook.class);
@@ -150,9 +153,18 @@ public final class PluginHookManager {
     public boolean isClaimed(@NotNull final Location location) {
         return getPluginHooks(ClaimPlugin.class, true)
                 .filter(plugin -> plugin.canUse(location.getWorld()))
-                .findFirst()
-                .map(hook -> hook.isClaimed(location))
-                .orElse(false);
+                .filter(hook -> !hook.isClaimed(location))
+                .toList()
+                .isEmpty();
+    }
+
+    @Contract(pure = true)
+    public boolean canAccess(final @NotNull Player player, final @NotNull Location location) {
+        return getPluginHooks(ClaimPlugin.class, true)
+                .filter(plugin -> plugin.canUse(location.getWorld()))
+                .filter(hook -> !hook.canAccess(player, location))
+                .toList()
+                .isEmpty();
     }
 
     @Contract(pure = true)

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/ConditionChecker.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/ConditionChecker.java
@@ -78,9 +78,10 @@ public class ConditionChecker {
                         + command);
 
         // Check if the player can teleport to that location if it's claimed
-        if (!teleportingPlayer.hasPermission("at.admin.bypass.claims")
-                && !PluginHookManager.get().canAccess(teleportingPlayer, toLoc)) {
-            return "Error.cantTPToLoc";
+        if (!teleportingPlayer.hasPermission("at.admin.bypass.claims")) {
+            if (MainConfig.get().MONITOR_ALL_TELEPORTS_LIMITS.get() || command != null) {
+                if (!PluginHookManager.get().canAccess(teleportingPlayer, toLoc)) return "Error.canTPToLoc";
+            }
         }
 
         // Check if the player is too far away

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/ConditionChecker.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/ConditionChecker.java
@@ -6,6 +6,7 @@ import io.github.niestrat99.advancedteleport.api.TeleportRequest;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 import io.github.niestrat99.advancedteleport.limitations.LimitationsManager;
 
+import io.github.niestrat99.advancedteleport.managers.PluginHookManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -75,6 +76,12 @@ public class ConditionChecker {
                         + CoreClass.getShortLocation(toLoc)
                         + " using command "
                         + command);
+
+        // Check if the player can teleport to that location if it's claimed
+        if (!teleportingPlayer.hasPermission("at.admin.bypass.claims")
+                && !PluginHookManager.get().canAccess(teleportingPlayer, toLoc)) {
+            return "Error.cantTPToLoc";
+        }
 
         // Check if the player is too far away
         if (MainConfig.get().ENABLE_DISTANCE_LIMITATIONS.get()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ dynmap = "3.4"
 playerParticles = "8.3"
 hangar = "0.0.5"
 slimjar = "1.6.1"
+factionsuuid = "1.6.9.5-U0.6.33"
 
 [libraries]
 paperlib = { module = "io.papermc:paperlib", version.ref = "paperlib" }
@@ -41,6 +42,7 @@ worldguard = { module = "com.sk89q.worldguard:worldguard-bukkit", version.ref = 
 squaremap = { module = "xyz.jpenilla:squaremap-api", version.ref = "squaremap" }
 dynmap = { module = "us.dynmap:dynmap-api", version.ref = "dynmap" }
 slimjar = { module = "dev.racci.slimjar:slimjar", version.ref = "slimjar" }
+factionsuuid = { module = "com.massivecraft:Factions", version.ref = "factionsuuid" }
 
 [plugins]
 hangar = { id = "io.papermc.hangar-publish-plugin", version.ref = "hangar" }


### PR DESCRIPTION
Integrates with the FactionsUUID plugin for claim checking.

Also adds:
- Protection for claimed areas from teleportation if the player cannot access them
- Protection from using `/sethome` and `/setwarp` if the player is not meant to have access to those areas
- The bypass permissions `at.admin.sethome.bypass.location`, `at.admin.setwarp.bypass.location` and `at.admin.bypass.claims`