### PR TITLE
Fix potential NPE when no other players online

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
@@ -77,6 +77,8 @@ public final class ATFloodgatePlayer extends ATPlayer {
                         return;
                     }
 
+                    if (response == null) return;
+
                     // Gets the chosen item
                     int i = response.getDropdown(0);
                     String result = items[i];


### PR DESCRIPTION
This PR added another null check to form response, in order to prevent null pointers when there's no other players online:)

logs: https://mclo.gs/To8KmiC