### PR TITLE
Check availability before sending dropdown form

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
@@ -91,7 +91,7 @@ public final class ATFloodgatePlayer extends ATPlayer {
     }
 
     @Contract(pure = true)
-    private @NotNull List<String> getVisiblePlayerNames() {
+    public @NotNull List<String> getVisiblePlayerNames() {
         return Bukkit.getOnlinePlayers().stream()
                 .filter(player -> player != getPlayer())
                 .filter(player -> getPlayer().canSee(player))
@@ -261,14 +261,7 @@ public final class ATFloodgatePlayer extends ATPlayer {
     }
 
     /** Sends the form for /tpcancel. */
-    public void sendCancelForm() {
-
-        // Builds the list of teleport requests that can be cancelled
-        final var responders =
-                TeleportRequest.getRequestsByRequester(getPlayer()).stream()
-                        .map(request -> request.requester().getName())
-                        .toList();
-
+    public void sendCancelForm(List<String> responders) {
         // Sends the dropdown menu form
         sendDropdownForm("tpcancel", responders);
     }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
@@ -77,6 +77,8 @@ public final class ATFloodgatePlayer extends ATPlayer {
                         return;
                     }
 
+                    if (response == null) return;
+
                     // Gets the chosen item
                     int i = response.getDropdown(0);
                     String result = items[i];

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/ATFloodgatePlayer.java
@@ -77,8 +77,6 @@ public final class ATFloodgatePlayer extends ATPlayer {
                         return;
                     }
 
-                    if (response == null) return;
-
                     // Gets the chosen item
                     int i = response.getDropdown(0);
                     String result = items[i];

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/DelHomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/DelHomeCommand.java
@@ -51,7 +51,11 @@ public final class DelHomeCommand extends AbstractHomeCommand implements PlayerC
         if (PluginHookManager.get().floodgateEnabled()
                 && atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                 && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-            atFloodgatePlayer.sendDeleteHomeForm();
+            if (!atFloodgatePlayer.getHomes().isEmpty()) {
+                atFloodgatePlayer.sendDeleteHomeForm();
+            } else {
+                CustomMessages.sendMessage(sender, "Error.noHomes");
+            }
         } else CustomMessages.sendMessage(sender, "Error.noHomeInput");
 
         return true;

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomesCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomesCommand.java
@@ -24,8 +24,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Set;
-
 public final class HomesCommand extends AbstractHomeCommand {
 
     @Override

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomesCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomesCommand.java
@@ -151,7 +151,7 @@ public final class HomesCommand extends AbstractHomeCommand {
                 && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
             CoreClass.debug("Sender is being sent a homes form.");
 
-            if (!body.content().isEmpty() || !body.children().isEmpty()) {
+            if (!atFloodgatePlayer.getHomes().isEmpty()) {
                 atFloodgatePlayer.sendHomeForm();
             } else {
                 CustomMessages.sendMessage(

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomesCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/HomesCommand.java
@@ -95,6 +95,24 @@ public final class HomesCommand extends AbstractHomeCommand {
 
     private void getHomes(CommandSender sender, OfflinePlayer target, ImmutableCollection<Home> homes) {
         ATPlayer atPlayer = ATPlayer.getPlayer(target);
+
+        if (sender == target
+                && atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
+                && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
+            CoreClass.debug("Sender is being sent a homes form.");
+
+            if (!atFloodgatePlayer.getHomes().isEmpty()) {
+                atFloodgatePlayer.sendHomeForm();
+            } else {
+                CustomMessages.sendMessage(
+                        sender,
+                        CustomMessages.contextualPath(sender, target, "Error.noHomes"),
+                        Placeholder.unparsed("player", target.getName()) // TODO: DisplayName
+                );
+            }
+            return;
+        }
+
         final TextComponent body = (TextComponent) Component.join(JoinConfiguration.commas(true),
                 homes.stream().map(home ->
                                 new Object[] {home,
@@ -145,23 +163,6 @@ public final class HomesCommand extends AbstractHomeCommand {
                                 })
                         .toList());
         CoreClass.debug("Message text built.");
-
-        if (sender == target
-                && atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
-                && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-            CoreClass.debug("Sender is being sent a homes form.");
-
-            if (!atFloodgatePlayer.getHomes().isEmpty()) {
-                atFloodgatePlayer.sendHomeForm();
-            } else {
-                CustomMessages.sendMessage(
-                        sender,
-                        CustomMessages.contextualPath(sender, target, "Error.noHomes"),
-                        Placeholder.unparsed("player", target.getName()) // TODO: DisplayName
-                );
-            }
-            return;
-        }
 
         if (!body.content().isEmpty() || !body.children().isEmpty()) {
             String text = CustomMessages.config.getString("Info.homes") + "<homes>";

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/MoveHomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/MoveHomeCommand.java
@@ -29,9 +29,13 @@ public final class MoveHomeCommand extends AbstractHomeCommand implements Player
         ATPlayer atPlayer = ATPlayer.getPlayer(player);
 
         if (args.length == 0) {
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendMoveHomeForm();
+                if (!atFloodgatePlayer.getHomes().isEmpty()) {
+                    atFloodgatePlayer.sendMoveHomeForm();
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noHomes");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noHomeInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpBlockCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpBlockCommand.java
@@ -31,7 +31,11 @@ public final class TpBlockCommand extends TeleportATCommand implements PlayerCom
         if (args.length == 0) {
             if (atPlayer instanceof ATFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendBlockForm();
+                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
+                    ((ATFloodgatePlayer) atPlayer).sendBlockForm();
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpBlockCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpBlockCommand.java
@@ -29,12 +29,12 @@ public final class TpBlockCommand extends TeleportATCommand implements PlayerCom
         ATPlayer atPlayer = ATPlayer.getPlayer(player);
 
         if (args.length == 0) {
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
-                    ((ATFloodgatePlayer) atPlayer).sendBlockForm();
+                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                    atFloodgatePlayer.sendBlockForm();
                 } else {
-                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                    CustomMessages.sendMessage(sender, "Error.noPlayerInput");
                 }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpCancel.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpCancel.java
@@ -75,9 +75,17 @@ public final class TpCancel extends TeleportATCommand implements PlayerCommand {
                 }
 
                 ATPlayer atPlayer = ATPlayer.getPlayer(player);
-                if (atPlayer instanceof ATFloodgatePlayer
+                if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                         && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                    ((ATFloodgatePlayer) atPlayer).sendCancelForm();
+                    final var responders =
+                            TeleportRequest.getRequestsByRequester(atFloodgatePlayer.getPlayer()).stream()
+                                    .map(request -> request.requester().getName())
+                                    .toList();
+                    if (!responders.isEmpty()) {
+                        ((ATFloodgatePlayer) atPlayer).sendCancelForm(responders);
+                    } else {
+                        CustomMessages.sendMessage(sender, "Error.noRequests");
+                    }
                     return true;
                 }
 

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpUnblock.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpUnblock.java
@@ -29,12 +29,12 @@ public final class TpUnblock extends TeleportATCommand implements PlayerCommand 
         Player player = (Player) sender;
         ATPlayer atPlayer = ATPlayer.getPlayer(player);
         if (args.length == 0) {
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
-                    ((ATFloodgatePlayer) atPlayer).sendUnblockForm();
+                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                    atFloodgatePlayer.sendUnblockForm();
                 } else {
-                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                    CustomMessages.sendMessage(sender, "Error.noPlayerInput");
                 }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpUnblock.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpUnblock.java
@@ -31,7 +31,11 @@ public final class TpUnblock extends TeleportATCommand implements PlayerCommand 
         if (args.length == 0) {
             if (atPlayer instanceof ATFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendUnblockForm();
+                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
+                    ((ATFloodgatePlayer) atPlayer).sendUnblockForm();
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpa.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpa.java
@@ -40,7 +40,11 @@ public final class Tpa extends TeleportATCommand implements TimedATCommand {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
             if (atPlayer instanceof ATFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendTPAForm(false);
+                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
+                    ((ATFloodgatePlayer) atPlayer).sendTPAForm(false);
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpa.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpa.java
@@ -38,10 +38,10 @@ public final class Tpa extends TeleportATCommand implements TimedATCommand {
 
         if (args.length == 0) {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
-                    ((ATFloodgatePlayer) atPlayer).sendTPAForm(false);
+                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                    atFloodgatePlayer.sendTPAForm(false);
                 } else {
                     CustomMessages.sendMessage(sender, "Error.noOthersToTP");
                 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpaHere.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpaHere.java
@@ -36,10 +36,10 @@ public final class TpaHere extends TeleportATCommand implements TimedATCommand {
 
         if (args.length == 0) {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
-                    ((ATFloodgatePlayer) atPlayer).sendTPAForm(true);
+                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                    atFloodgatePlayer.sendTPAForm(true);
                 } else {
                     CustomMessages.sendMessage(sender, "Error.noOthersToTP");
                 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpaHere.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpaHere.java
@@ -38,7 +38,11 @@ public final class TpaHere extends TeleportATCommand implements TimedATCommand {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
             if (atPlayer instanceof ATFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendTPAForm(true);
+                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
+                    ((ATFloodgatePlayer) atPlayer).sendTPAForm(true);
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
@@ -29,10 +29,10 @@ public final class Tpo extends TeleportATCommand implements PlayerCommand {
 
         if (args.length == 0) {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
-                    ((ATFloodgatePlayer) atPlayer).sendTpoForm();
+                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                    atFloodgatePlayer.sendTpoForm();
                 } else {
                     CustomMessages.sendMessage(sender, "Error.noOthersToTP");
                 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
@@ -31,7 +31,11 @@ public final class Tpo extends TeleportATCommand implements PlayerCommand {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
             if (atPlayer instanceof ATFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendTpoForm();
+                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
+                    ((ATFloodgatePlayer) atPlayer).sendTpoForm();
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpoHere.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpoHere.java
@@ -30,7 +30,11 @@ public final class TpoHere extends TeleportATCommand implements PlayerCommand {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
             if (atPlayer instanceof ATFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendTpoHereForm();
+                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
+                    ((ATFloodgatePlayer) atPlayer).sendTpoHereForm();
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noPlayerInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpoHere.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/TpoHere.java
@@ -28,10 +28,10 @@ public final class TpoHere extends TeleportATCommand implements PlayerCommand {
         Player player = (Player) sender;
         if (args.length == 0) {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!((ATFloodgatePlayer) atPlayer).getVisiblePlayerNames().isEmpty()) {
-                    ((ATFloodgatePlayer) atPlayer).sendTpoHereForm();
+                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                    atFloodgatePlayer.sendTpoHereForm();
                 } else {
                     CustomMessages.sendMessage(sender, "Error.noOthersToTP");
                 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/DeleteWarpCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/DeleteWarpCommand.java
@@ -30,9 +30,13 @@ public final class DeleteWarpCommand extends AbstractWarpCommand {
         if (args.length == 0) {
             if (sender instanceof Player player) {
                 ATPlayer atPlayer = ATPlayer.getPlayer(player);
-                if (atPlayer instanceof ATFloodgatePlayer
+                if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                         && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                    ((ATFloodgatePlayer) atPlayer).sendDeleteWarpForm();
+                    if (!AdvancedTeleportAPI.getWarps().isEmpty()) {
+                        atFloodgatePlayer.sendDeleteWarpForm();
+                    } else {
+                        CustomMessages.sendMessage(sender, "Error.noWarps");
+                    }
                     return true;
                 }
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/MoveWarpCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/MoveWarpCommand.java
@@ -33,9 +33,13 @@ public final class MoveWarpCommand extends AbstractWarpCommand {
         // continue
         if (args.length == 0) {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendMoveWarpForm();
+                if (!AdvancedTeleportAPI.getWarps().isEmpty()) {
+                    atFloodgatePlayer.sendMoveWarpForm();
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noWarps");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noWarpInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/WarpCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/warp/WarpCommand.java
@@ -34,9 +34,13 @@ public final class WarpCommand extends AbstractWarpCommand implements TimedATCom
         // If there's no arguments specified, see if the player is a Bedrock player and use a form
         if (args.length == 0) {
             ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer
+            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
                     && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                ((ATFloodgatePlayer) atPlayer).sendWarpForm();
+                if (!AdvancedTeleportAPI.getWarps().isEmpty()) {
+                    atFloodgatePlayer.sendWarpForm();
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noWarps");
+                }
             } else {
                 CustomMessages.sendMessage(sender, "Error.noWarpInput");
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -284,6 +284,7 @@ public final class CustomMessages extends ATConfig {
                 "<prefix> <gray>You can't teleport to <aqua><world></aqua>!");
         addDefault("Error.tooFewArguments", "<prefix> <gray>Too few arguments!");
         addDefault("Error.invalidArgs", "<prefix> <gray>Invalid arguments!");
+        addDefault("Error.noOthersToTP", "<prefix> <gray>There are no players for you to teleport!");
         addDefault(
                 "Error.cantTPToPlayer",
                 "<prefix> <gray>You can't request a teleportation to <aqua><player></aqua>!");


### PR DESCRIPTION
This pull request adds availability check to all bedrock dropdown forms.

Changes:

- Added checks to Tpa, Tpahere, Tpablock, Tpaunblock, Tpo, Tpohere, Warps, Setwarp, Movewarp, Delwarp, Homes, Home, Delhome form
- ~~Made TextComponent of home command be built earlier~~
- Added one message key: `Error.noOthersToTP`
- Made accessibility of `getVisibleNames` method from private to public
- `sendCancelForm` method now requires a list parameter