### PR TITLE
Re-coded TPO command

### DIFF
--- a/AdvancedTeleport-Bukkit/build.gradle.kts
+++ b/AdvancedTeleport-Bukkit/build.gradle.kts
@@ -573,6 +573,7 @@ bukkit {
                 "at.admin.tpohere" to true,
                 "at.admin.all" to true,
                 "at.admin.tpo" to true,
+                "at.admin.tpo.others" to true,
                 "at.admin.setwarp" to true,
                 "at.admin.delwarp" to true,
                 "at.admin.setspawn" to true,

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
@@ -2,13 +2,10 @@ package io.github.niestrat99.advancedteleport.commands.teleport;
 
 import io.github.niestrat99.advancedteleport.api.ATFloodgatePlayer;
 import io.github.niestrat99.advancedteleport.api.ATPlayer;
-import io.github.niestrat99.advancedteleport.commands.PlayerCommand;
 import io.github.niestrat99.advancedteleport.commands.TeleportATCommand;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
-
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -16,7 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.NotNull;
 
-public final class Tpo extends TeleportATCommand implements PlayerCommand {
+public final class Tpo extends TeleportATCommand {
 
     @Override
     public boolean onCommand(
@@ -24,40 +21,83 @@ public final class Tpo extends TeleportATCommand implements PlayerCommand {
             @NotNull final Command command,
             @NotNull final String s,
             @NotNull final String[] args) {
-        if (!canProceed(sender)) return true;
-        Player player = (Player) sender;
 
-        if (args.length == 0) {
-            ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
-                    && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
-                    atFloodgatePlayer.sendTpoForm();
-                } else {
-                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
-                }
-            } else {
-                CustomMessages.sendMessage(sender, "Error.noPlayerInput");
+        if (args.length > 1) {
+            if (!sender.hasPermission("at.admin.tpo.others")) {
+                CustomMessages.sendMessage(sender, "Error.noPermission");
+                return true;
             }
-            return true;
-        }
-        if (args[0].equalsIgnoreCase(player.getName())) {
-            CustomMessages.sendMessage(sender, "Error.requestSentToSelf");
-            return true;
-        }
-        Player target = Bukkit.getPlayer(args[0]);
-        if (target == null) {
-            CustomMessages.sendMessage(sender, "Error.noSuchPlayer");
+
+            Player target1 = Bukkit.getPlayerExact(args[0]);
+            Player target2 = Bukkit.getPlayerExact(args[1]);
+
+            if (target1 != null && target2 != null) {
+                if (sender instanceof Player player && (target1 == player && target2 == player)) {
+                    CustomMessages.sendMessage(player, "Error.requestSentToSelf");
+                    return true;
+                }
+
+                CustomMessages.sendMessage(sender,
+                        "Teleport.teleportingOneToAnother",
+                        Placeholder.unparsed("player1", target1.getName()),
+                        Placeholder.unparsed("player2", target2.getName())
+                );
+                CustomMessages.sendMessage(target1,
+                        "Teleport.teleporting",
+                        Placeholder.unparsed("player", target2.getName())
+                );
+                ATPlayer.teleportWithOptions(
+                        target1, target2.getLocation(),
+                        PlayerTeleportEvent.TeleportCause.COMMAND
+                );
+            } else {
+                CustomMessages.sendMessage(sender, "Error.noSuchPlayer");
+                return true;
+            }
+        } else if (args.length > 0){
+            if (sender instanceof Player player) {
+                if (args[0].equalsIgnoreCase(player.getName())) {
+                    CustomMessages.sendMessage(sender, "Error.requestSentToSelf");
+                    return true;
+                }
+
+                Player target = Bukkit.getPlayerExact(args[0]);
+                if (target == null) {
+                    CustomMessages.sendMessage(sender, "Error.noSuchPlayer");
+                    return true;
+                } else {
+                    CustomMessages.sendMessage(
+                            sender, "Teleport.teleporting",
+                            Placeholder.unparsed("player", target.getName())
+                    );
+                    ATPlayer.teleportWithOptions(
+                            player, target.getLocation(),
+                            PlayerTeleportEvent.TeleportCause.COMMAND
+                    );
+                }
+
+            } else {
+                CustomMessages.sendMessage(sender,"Error.notAPlayer");
+                return true;
+            }
         } else {
-            CustomMessages.sendMessage(
-                    sender,
-                    "Teleport.teleporting",
-                    Placeholder.unparsed("player", target.getName()));
-            ATPlayer.teleportWithOptions(
-                    player, target.getLocation(), PlayerTeleportEvent.TeleportCause.COMMAND);
+            if (sender instanceof Player player) {
+                ATPlayer atPlayer = ATPlayer.getPlayer(player);
+                if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
+                        && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
+                    if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                        atFloodgatePlayer.sendTpoForm();
+                    } else {
+                        CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                    }
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noPlayerInput");
+                }
+            }
         }
         return true;
     }
+
 
     @Override
     public @NotNull String getPermission() {

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -176,6 +176,10 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Teleport.teleportedOfflinePlayerHere",
                 "<prefix> <gray>Teleported offline player <aqua><player></aqua> to your location!");
+        addDefault(
+                "Teleport.teleportingOneToAnother",
+                "<prefix> <gray>Teleporting <aqua><player1></aqua> to <aqua><player2></aqua>!"
+        );
 
         makeSectionLenient("Error");
         addDefault(


### PR DESCRIPTION
I have revamped the TPO command to allow the command user to teleport one player to another.

With that, I also added a new custom message "teleport.teleportingOneAnother" and a new permission node "at.admin.tpo.others".