### PR TITLE
Added config option to blacklist death causes.

### DIFF
--- a/AdvancedTeleport-Bukkit/build.gradle.kts
+++ b/AdvancedTeleport-Bukkit/build.gradle.kts
@@ -573,6 +573,7 @@ bukkit {
                 "at.admin.tpohere" to true,
                 "at.admin.all" to true,
                 "at.admin.tpo" to true,
+                "at.admin.tpo.others" to true,
                 "at.admin.setwarp" to true,
                 "at.admin.delwarp" to true,
                 "at.admin.setspawn" to true,

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/teleport/Tpo.java
@@ -2,13 +2,10 @@ package io.github.niestrat99.advancedteleport.commands.teleport;
 
 import io.github.niestrat99.advancedteleport.api.ATFloodgatePlayer;
 import io.github.niestrat99.advancedteleport.api.ATPlayer;
-import io.github.niestrat99.advancedteleport.commands.PlayerCommand;
 import io.github.niestrat99.advancedteleport.commands.TeleportATCommand;
 import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
-
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -16,7 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.NotNull;
 
-public final class Tpo extends TeleportATCommand implements PlayerCommand {
+public final class Tpo extends TeleportATCommand {
 
     @Override
     public boolean onCommand(
@@ -24,40 +21,83 @@ public final class Tpo extends TeleportATCommand implements PlayerCommand {
             @NotNull final Command command,
             @NotNull final String s,
             @NotNull final String[] args) {
-        if (!canProceed(sender)) return true;
-        Player player = (Player) sender;
 
-        if (args.length == 0) {
-            ATPlayer atPlayer = ATPlayer.getPlayer(player);
-            if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
-                    && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
-                if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
-                    atFloodgatePlayer.sendTpoForm();
-                } else {
-                    CustomMessages.sendMessage(sender, "Error.noOthersToTP");
-                }
-            } else {
-                CustomMessages.sendMessage(sender, "Error.noPlayerInput");
+        if (args.length > 1) {
+            if (!sender.hasPermission("at.admin.tpo.others")) {
+                CustomMessages.sendMessage(sender, "Error.noPermission");
+                return true;
             }
-            return true;
-        }
-        if (args[0].equalsIgnoreCase(player.getName())) {
-            CustomMessages.sendMessage(sender, "Error.requestSentToSelf");
-            return true;
-        }
-        Player target = Bukkit.getPlayer(args[0]);
-        if (target == null) {
-            CustomMessages.sendMessage(sender, "Error.noSuchPlayer");
+
+            Player target1 = Bukkit.getPlayerExact(args[0]);
+            Player target2 = Bukkit.getPlayerExact(args[1]);
+
+            if (target1 != null && target2 != null) {
+                if (sender instanceof Player player && (target1 == player && target2 == player)) {
+                    CustomMessages.sendMessage(player, "Error.requestSentToSelf");
+                    return true;
+                }
+
+                CustomMessages.sendMessage(sender,
+                        "Teleport.teleportingOneToAnother",
+                        Placeholder.unparsed("player1", target1.getName()),
+                        Placeholder.unparsed("player2", target2.getName())
+                );
+                CustomMessages.sendMessage(target1,
+                        "Teleport.teleporting",
+                        Placeholder.unparsed("player", target2.getName())
+                );
+                ATPlayer.teleportWithOptions(
+                        target1, target2.getLocation(),
+                        PlayerTeleportEvent.TeleportCause.COMMAND
+                );
+            } else {
+                CustomMessages.sendMessage(sender, "Error.noSuchPlayer");
+                return true;
+            }
+        } else if (args.length > 0){
+            if (sender instanceof Player player) {
+                if (args[0].equalsIgnoreCase(player.getName())) {
+                    CustomMessages.sendMessage(sender, "Error.requestSentToSelf");
+                    return true;
+                }
+
+                Player target = Bukkit.getPlayerExact(args[0]);
+                if (target == null) {
+                    CustomMessages.sendMessage(sender, "Error.noSuchPlayer");
+                    return true;
+                } else {
+                    CustomMessages.sendMessage(
+                            sender, "Teleport.teleporting",
+                            Placeholder.unparsed("player", target.getName())
+                    );
+                    ATPlayer.teleportWithOptions(
+                            player, target.getLocation(),
+                            PlayerTeleportEvent.TeleportCause.COMMAND
+                    );
+                }
+
+            } else {
+                CustomMessages.sendMessage(sender,"Error.notAPlayer");
+                return true;
+            }
         } else {
-            CustomMessages.sendMessage(
-                    sender,
-                    "Teleport.teleporting",
-                    Placeholder.unparsed("player", target.getName()));
-            ATPlayer.teleportWithOptions(
-                    player, target.getLocation(), PlayerTeleportEvent.TeleportCause.COMMAND);
+            if (sender instanceof Player player) {
+                ATPlayer atPlayer = ATPlayer.getPlayer(player);
+                if (atPlayer instanceof ATFloodgatePlayer atFloodgatePlayer
+                        && MainConfig.get().USE_FLOODGATE_FORMS.get()) {
+                    if (!atFloodgatePlayer.getVisiblePlayerNames().isEmpty()) {
+                        atFloodgatePlayer.sendTpoForm();
+                    } else {
+                        CustomMessages.sendMessage(sender, "Error.noOthersToTP");
+                    }
+                } else {
+                    CustomMessages.sendMessage(sender, "Error.noPlayerInput");
+                }
+            }
         }
         return true;
     }
+
 
     @Override
     public @NotNull String getPermission() {

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -176,6 +176,10 @@ public final class CustomMessages extends ATConfig {
         addDefault(
                 "Teleport.teleportedOfflinePlayerHere",
                 "<prefix> <gray>Teleported offline player <aqua><player></aqua> to your location!");
+        addDefault(
+                "Teleport.teleportingOneToAnother",
+                "<prefix> <gray>Teleporting <aqua><player1></aqua> to <aqua><player2></aqua>!"
+        );
 
         makeSectionLenient("Error");
         addDefault(

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
@@ -113,6 +113,7 @@ public final class MainConfig extends ATConfig {
     public ConfigOption<Boolean> RETAIN_VEHICLES;
     public ConfigOption<Boolean> RETAIN_LIVING_ONLY;
     public ConfigOption<Boolean> TELEPORT_ON_SIGN_SIDE;
+    public ConfigOption<List<String>> DEATHCAUSE_BLACKLIST;
 
     /** */
     public MainConfig() throws Exception {
@@ -702,6 +703,15 @@ public final class MainConfig extends ATConfig {
                 If a player teleports from an unsafe location and uses /back to return to it, the plugin will search all blocks within this radius to see if it is a safe place for the player to be moved to.
                 It is recommend to avoid setting this option too high as this can have a worst case execution time of O(n^3) (e.g. run 27 times, 64, 125, 216 and so on).
                 To disable, either set to 0 or -1.""");
+        addDefault(
+                "deathcause-blacklist",
+                new ArrayList<>(),
+                """
+        If a player dies through a blacklisted death cause then it won't be able to teleport back to it's location of death.
+        Each death cause has to be written in all caps.
+        List of death causes: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html
+        """
+        );
 
         addSection("Map Plugin Integration");
         addComment(
@@ -1100,6 +1110,7 @@ public final class MainConfig extends ATConfig {
 
         BACK_TELEPORT_CAUSES = new ConfigOption<>("used-teleport-causes");
         BACK_SEARCH_RADIUS = new ConfigOption<>("back-search-radius");
+        DEATHCAUSE_BLACKLIST = new ConfigOption<>("deathcause-blacklist");
 
         MAP_HOMES = new MapOptions("homes");
         MAP_SPAWNS = new MapOptions("spawns");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
@@ -19,11 +19,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 public class TeleportTrackingManager implements Listener {
 
@@ -135,11 +138,14 @@ public class TeleportTrackingManager implements Listener {
 
         // If it's an NPC, once again, couldn't care less
         if (e.getEntity().hasMetadata("NPC")) return;
-
+        EntityDamageEvent.DamageCause deathCause = Objects.requireNonNull(e.getPlayer().getLastDamageCause()).getCause();
+        CoreClass.debug(e.getEntity().getName() + " died by following cause: " + deathCause.name());
         // If the player can have their death location set, then set it
         if (MainConfig.get().USE_BASIC_TELEPORT_FEATURES.get()
-                && e.getEntity().hasPermission("at.member.back.death")) {
-            ATPlayer.getPlayer(e.getEntity()).setPreviousLocation(e.getEntity().getLocation());
+                && e.getEntity().hasPermission("at.member.back.death")
+                && !MainConfig.get().DEATHCAUSE_BLACKLIST.get().contains(deathCause.name())) {
+                CoreClass.debug("Death cause is not blacklisted. Saving death location.");
+                ATPlayer.getPlayer(e.getEntity()).setPreviousLocation(e.getEntity().getLocation());
         }
     }
 


### PR DESCRIPTION
Basically, if you enter any of the damage / death causes to the list in the config.yml then the back command will not save the player's death location.