### PR TITLE
feat: add commands to run on certain events

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
@@ -43,9 +43,16 @@ public final class MainConfig extends ATConfig {
     public ConfigOption<Object> COST_AMOUNT;
     public PerCommandOption<Object> COSTS;
     public ConfigOption<ConfigSection> CUSTOM_COSTS;
+
     public ConfigOption<Boolean> USE_PARTICLES;
     public PerCommandOption<String> TELEPORT_PARTICLES;
     public PerCommandOption<String> WAITING_PARTICLES;
+
+    public PerCommandOption<Object> COMMANDS_ON_WARM_UP;
+    public PerCommandOption<Object> COMMANDS_ON_TELEPORT;
+    public PerCommandOption<Object> COMMANDS_ON_COOLDOWN_EXPIRE;
+    public PerCommandOption<Object> COMMANDS_ON_CANCEL;
+
     public ConfigOption<Boolean> USE_MYSQL;
     public ConfigOption<String> MYSQL_HOST;
     public ConfigOption<Integer> MYSQL_PORT;
@@ -209,14 +216,8 @@ public final class MainConfig extends ATConfig {
                 "Whether the plugin should check for change in exact X, Y and Z vs. block X, Y, Z.\n" +
                         "By default, the player will have to cross into a new block (e.g. 60x 60y 60z -> 61x 60y 60z) to cancel the teleportation.");
 
-        addComment("per-command-warm-ups", "Command-specific warm-ups.");
-        addDefault("per-command-warm-ups.tpa", "default", "Warm-up timer for /tpa.");
-        addDefault("per-command-warm-ups.tpahere", "default", "Warm-up timer for /tpahere");
-        addDefault("per-command-warm-ups.tpr", "default", "Warm-up timer for /tpr, or /rtp.");
-        addDefault("per-command-warm-ups.warp", "default", "Warm-up timer for /warp");
-        addDefault("per-command-warm-ups.spawn", "default", "Warm-up timer for /spawn");
-        addDefault("per-command-warm-ups.home", "default", "Warm-up timer for /home");
-        addDefault("per-command-warm-ups.back", "default", "Warm-up timer for /back");
+        addCommandDefaults("per-command-warm-ups", "Command-specific warm-ups.");
+
         addComment(
                 """
                 Use this section to create custom warm-ups per-group.
@@ -270,14 +271,7 @@ public final class MainConfig extends ATConfig {
                 cooldown for /tpall always starts when the command is ran, regardless if any player accepts or teleports\
                 """);
 
-        addComment("per-command-cooldowns", "Command-specific cooldowns.");
-        addDefault("per-command-cooldowns.tpa", "default", "Cooldown for /tpa.");
-        addDefault("per-command-cooldowns.tpahere", "default", "Cooldown for /tpahere");
-        addDefault("per-command-cooldowns.tpr", "default", "Cooldown for /tpr, or /rtp.");
-        addDefault("per-command-cooldowns.warp", "default", "Cooldown for /warp");
-        addDefault("per-command-cooldowns.spawn", "default", "Cooldown for /spawn");
-        addDefault("per-command-cooldowns.home", "default", "Cooldown for /home");
-        addDefault("per-command-cooldowns.back", "default", "Cooldown for /back");
+        addCommandDefaults("per-command-cooldowns", "Command-specific cooldowns.");
         // addDefault("per-command-cooldowns.sethome", "default", "Cooldown for /sethome");
         // addDefault("per-command-cooldowns.setwarp", "default", "Cooldown for /setwarp");
         makeSectionLenient("custom-cooldowns");
@@ -311,16 +305,10 @@ public final class MainConfig extends ATConfig {
                 To use multiple methods of charging, use a ; - e.g. '100.0;10LVL' for $100 and 10 EXP levels.
                 To disable, just put an empty string, i.e. ''""");
 
-        addComment("per-command-cost", "Command-specific costs.");
-        addDefault("per-command-cost.tpa", "default", "Cost for /tpa.");
-        addDefault("per-command-cost.tpahere", "default", "Cost for /tpahere.");
-        addDefault("per-command-cost.tpr", "default", "Cost for /tpr, or /rtp.");
-        addDefault("per-command-cost.warp", "default", "Cost for /warp");
-        addDefault("per-command-cost.spawn", "default", "Cost for /spawn");
-        addDefault("per-command-cost.home", "default", "Cost for /home");
-        addDefault("per-command-cost.back", "default", "Cost for /back");
+        addCommandDefaults("per-command-cost", "Command-specific costs.");
         // addDefault("per-command-cost.sethome", "default", "Cost for /sethome");
         // addDefault("pet-command-cost.setwarp", "default", "Cost for /setwarp");
+
         makeSectionLenient("custom-costs");
         addComment(
                 "custom-costs",
@@ -343,28 +331,93 @@ public final class MainConfig extends ATConfig {
                 "default-waiting-particles",
                 "",
                 "The default waiting particles during the warm-up period.");
-        addComment("waiting-particles", "Command-specific waiting particles.");
-        addDefault("waiting-particles.tpa", "default");
-        addDefault("waiting-particles.tpahere", "default");
-        addDefault("waiting-particles.tpr", "default");
-        addDefault("waiting-particles.warp", "default");
-        addDefault("waiting-particles.spawn", "default");
-        addDefault("waiting-particles.home", "default");
-        addDefault("waiting-particles.back", "default");
+        addCommandDefaults("waiting-particles", "Command-specific waiting particles.");
 
         addDefault(
                 "default-teleporting-particles",
                 "spark",
                 "The default particles used as soon as the player teleports. \n"
                         + "At this time, only spark is supported. However, other recommendations are welcome with that.");
-        addComment("teleporting-particles", "Command-specific teleporting particles.");
-        addDefault("teleporting-particles.tpa", "default");
-        addDefault("teleporting-particles.tpahere", "default");
-        addDefault("teleporting-particles.tpr", "default");
-        addDefault("teleporting-particles.warp", "default");
-        addDefault("teleporting-particles.spawn", "default");
-        addDefault("teleporting-particles.home", "default");
-        addDefault("teleporting-particles.back", "default");
+        addCommandDefaults("teleporting-particles", "Command-specific teleporting particles.");
+
+        addSection("Commands on Events");
+
+        addComment("""
+                This section outlines commands that can run on certain events.
+                One command can be written on a single line, or as a list to indicate multiple commands.
+                You can choose whether the player or server runs the commands, e.g.:
+                
+                default-commands-on-warm-up-start:
+                - player;say I am getting ready to teleport!
+                - server;spawnparticle
+                
+                By default, any specified command is run by the player who executed the command.
+                
+                The following placeholders are available for all commands:
+                - {player} - the player who ran the command.
+                - {command} - the command the player ran.
+                
+                And these placeholders are available depending on the commands being run:
+                - /warp - {warp} - the name of the warp being teleported to.
+                - /tpa - {target} - the player being teleported to.
+                - /tpahere - {target} - the player being teleported to the executor.
+                - /spawn - {spawn} - the name of the spawnpoint being teleported to.
+                - /home - {home} - the name of the home being teleported to.
+                
+                Any placeholders for the specific events will be specified in their respective sections.""");
+
+        // Have commands run when warm-ups begin
+        addDefault(
+                "default-commands-on-warm-up-start",
+                new ArrayList<>(),
+                """
+                The default commands to run when a player's teleport warm-up begins. The following placeholders are available:
+                - {duration} - the warm-up duration in seconds.
+                - {x} or {block_x} - the x coordinate the player is teleporting to (where block is a whole number).
+                - {y} or {block_y} - the y coordinate the player is teleporting to (where block is a whole number).
+                - {z} or {block_z} - the z coordinate the player is teleporting to (where block is a whole number).
+                - {yaw} - the yaw the player will be changed to after teleporting.
+                - {pitch} - the pitch the player will be changed to after teleporting.
+                - {world} - the world the player is teleporting to.
+                
+                For /tpahere, the {player} variable is not the one affected by the warm-up - but rather the {target}.
+                If a player skips the warm-up, then the commands will not be run.""");
+        addCommandDefaults("commands-on-warm-up-start",
+                "The individual commands run for each teleport command when their warm-ups initiate.");
+
+        // Have commands run when teleporting actually happens
+        addDefault(
+                "default-commands-on-teleport",
+                new ArrayList<>(),
+                """
+                The default commands to run immediately after a player teleports. The following placeholders are available:
+                - {x} or {block_x} - the x coordinate the player is teleporting to (where block is a whole number).
+                - {y} or {block_y} - the y coordinate the player is teleporting to (where block is a whole number).
+                - {z} or {block_z} - the z coordinate the player is teleporting to (where block is a whole number).
+                - {yaw} - the yaw the player will be changed to after teleporting.
+                - {pitch} - the pitch the player will be changed to after teleporting.
+                - {world} - the world the player is teleporting to.""");
+        addCommandDefaults("commands-on-teleport",
+                "The individual commands run for each teleport command when the player teleports.");
+
+        // Have commands run when cooldowns expire
+        addDefault(
+                "default-commands-on-cooldown-expire",
+                new ArrayList<>(),
+                """
+                The default commands to run when the cooldown on a command expires.""");
+        addCommandDefaults("commands-on-cooldown-expire",
+                "The individual commands run for each teleport command when their respective cooldown expires.");
+
+        // Have commands run when teleports are cancelled
+        addDefault(
+                "default-commands-on-cancel",
+                new ArrayList<>(),
+                """
+                The default commands to run when a teleportation is cancelled, e.g. due to movement. It is not for the
+                cancellation of teleportation requests using /tpcancel.""");
+        addCommandDefaults("commands-on-cancel",
+                "The individual commands run for each teleport command when their teleportation is cancelled.");
 
         addSection("SQL Storage");
 
@@ -1047,6 +1100,11 @@ public final class MainConfig extends ATConfig {
         TELEPORT_PARTICLES =
                 new PerCommandOption<>("teleporting-particles", "default-teleporting-particles");
 
+        COMMANDS_ON_WARM_UP = new PerCommandOption<>("commands-on-warm-up-start", "default-commands-on-warm-up-start");
+        COMMANDS_ON_TELEPORT = new PerCommandOption<>("commands-on-teleport", "default-commands-on-teleport");
+        COMMANDS_ON_COOLDOWN_EXPIRE = new PerCommandOption<>("commands-on-cooldown-expire", "default-commands-on-cooldown-expire");
+        COMMANDS_ON_CANCEL = new PerCommandOption<>("commands-on-cancel", "default-commands-on-cancel");
+
         USE_MYSQL = new ConfigOption<>("use-mysql");
         MYSQL_HOST = new ConfigOption<>("mysql-host");
         MYSQL_PORT = new ConfigOption<>("mysql-port");
@@ -1200,6 +1258,13 @@ public final class MainConfig extends ATConfig {
             }
             permObject.setDefault(PermissionDefault.TRUE);
             defaults.add(permission);
+        }
+    }
+
+    private void addCommandDefaults(String parentKey, String comment) {
+        addComment(parentKey, comment);
+        for (String command : new String[]{"tpa", "tpahere", "warp", "home", "back", "spawn", "tpr"}) {
+            addDefault(parentKey + "." + command, "default");
         }
     }
 

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/CooldownManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/CooldownManager.java
@@ -4,18 +4,15 @@ import io.github.niestrat99.advancedteleport.CoreClass;
 import io.github.niestrat99.advancedteleport.api.ATPlayer;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 
-import org.bukkit.Bukkit;
+import io.github.niestrat99.advancedteleport.utilities.CommandRunner;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
+import java.lang.ref.WeakReference;
+import java.util.*;
 
 public class CooldownManager {
 
@@ -30,7 +27,7 @@ public class CooldownManager {
                 return (int)
                         Math.ceil(
                                 (runnable.startingTime
-                                                + runnable.ms * 1000
+                                                + runnable.duration * 1000
                                                 - System.currentTimeMillis())
                                         / 1000.0);
             }
@@ -43,7 +40,7 @@ public class CooldownManager {
         ATPlayer atPlayer = ATPlayer.getPlayer(player);
         list.add(
                 new ATRunnable(
-                        player.getUniqueId(), atPlayer.getCooldown(command, toWorld), command));
+                        player, atPlayer.getCooldown(command, toWorld), command));
         cooldown.put(getKey(command), list);
     }
 
@@ -64,32 +61,39 @@ public class CooldownManager {
     }
 
     public static class ATRunnable extends BukkitRunnable {
+        private final WeakReference<Player> player;
         private final UUID uuid;
         private final long startingTime;
         private final String command;
-        private long ms;
+        private long duration;
 
-        public ATRunnable(UUID uuid, long waitingTime, String command) {
-            this.uuid = uuid;
-            ms = waitingTime;
+        public ATRunnable(Player player, long waitingTime, String command) {
+            this.player = new WeakReference<>(player);
+            this.uuid = player.getUniqueId();
+            this.duration = waitingTime;
             if (MainConfig.get().ADD_COOLDOWN_DURATION_TO_WARM_UP.get()
-                    && !Bukkit.getPlayer(uuid).hasPermission("at.admin.bypass.timer")) {
-                ms += MainConfig.get().WARM_UPS.valueOf(command).get();
+                    && !player.hasPermission("at.admin.bypass.timer")) {
+                this.duration += MainConfig.get().WARM_UPS.valueOf(command).get();
             }
-            this.command = getKey(command);
+            this.command = command;
             startingTime = System.currentTimeMillis();
             runTaskLater(CoreClass.getInstance());
         }
 
         public synchronized BukkitTask runTaskLater(Plugin plugin)
                 throws IllegalArgumentException, IllegalStateException {
-            return super.runTaskLater(plugin, ms * 20);
+            return super.runTaskLater(plugin, duration * 20);
         }
 
         @Override
         public void run() {
-            List<ATRunnable> list = cooldown.get(command);
+            List<ATRunnable> list = cooldown.get(getKey(command));
             list.remove(this);
+
+            Player player = this.player.get();
+            if (player == null) return;
+            CommandRunner.runCommandsOnCooldownExpire(
+                    this.command, player, new CommandRunner.Placeholder("duration", this.duration));
         }
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/MovementManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/MovementManager.java
@@ -6,6 +6,7 @@ import io.github.niestrat99.advancedteleport.config.CustomMessages;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 import io.github.niestrat99.advancedteleport.payments.PaymentManager;
 
+import io.github.niestrat99.advancedteleport.utilities.CommandRunner;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
@@ -18,6 +19,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -38,6 +40,8 @@ public class MovementManager implements Listener {
             CustomMessages.sendMessage(event.getPlayer(), "Teleport.eventMovement");
             ParticleManager.removeParticles(event.getPlayer(), timer.command);
             movement.remove(uuid);
+
+            CommandRunner.runCommandsOnCancel(timer.command, event.getPlayer());
         }
     }
 
@@ -90,7 +94,7 @@ public class MovementManager implements Listener {
             String command,
             String message,
             int warmUp,
-            TagResolver... placeholders) {
+            TagResolver.Single... placeholders) {
         createMovementTimer(
                 teleportingPlayer,
                 location,
@@ -98,9 +102,23 @@ public class MovementManager implements Listener {
                 message,
                 warmUp,
                 teleportingPlayer,
+                null,
                 placeholders);
     }
 
+    /**
+     * Creates a timer that represents the warm-up before a player teleports.
+     *
+     * @param teleportingPlayer the player that is teleporting.
+     * @param location the location teleportingPlayer is teleporting to.
+     * @param command the name of the command used to trigger the teleportation.
+     * @param message the message key used once the player has teleported.
+     * @param warmUp the warm-up duration in seconds.
+     * @param payingPlayer the player paying for the teleportation. This might not be the one teleporting, e.g. when
+     *                     using /tpahere.
+     * @param toPlayer the player being teleported to if using /tpa or /tpahere.
+     * @param placeholders placeholders to use in the message key.
+     */
     public static void createMovementTimer(
             Player teleportingPlayer,
             Location location,
@@ -108,7 +126,8 @@ public class MovementManager implements Listener {
             String message,
             int warmUp,
             Player payingPlayer,
-            TagResolver... placeholders) {
+            @Nullable Player toPlayer,
+            TagResolver.Single... placeholders) {
         UUID uuid = teleportingPlayer.getUniqueId();
 
         // When this config is enabled the teleporting player will receive a blindness effect until
@@ -131,15 +150,18 @@ public class MovementManager implements Listener {
                         // If the player can't pay for the
                         if (!PaymentManager.getInstance()
                                 .canPay(command, payingPlayer, location.getWorld())) return;
+
                         ParticleManager.onTeleport(teleportingPlayer, command);
                         ATPlayer.teleportWithOptions(
                                 teleportingPlayer,
                                 location,
                                 PlayerTeleportEvent.TeleportCause.COMMAND);
+
                         movement.remove(uuid);
                         CustomMessages.sendMessage(teleportingPlayer, message, placeholders);
                         PaymentManager.getInstance()
                                 .withdraw(command, payingPlayer, location.getWorld());
+
                         // If the cooldown is to be applied after only after a teleport takes place,
                         // apply it now
                         if (MainConfig.get()
@@ -149,8 +171,26 @@ public class MovementManager implements Listener {
                             CooldownManager.addToCooldown(
                                     command, payingPlayer, location.getWorld());
                         }
+
+                        if (toPlayer != null) {
+
+                            CommandRunner.runCommandsOnTeleport(
+                                    command,
+                                    location,
+                                    payingPlayer,
+                                    tagResolversToPlaceholders(
+                                            placeholders, new CommandRunner.Placeholder("target",
+                                                    command.equals("tpa") ? toPlayer.getName() : teleportingPlayer.getName())));
+                        } else {
+                            CommandRunner.runCommandsOnTeleport(
+                                    command,
+                                    location,
+                                    payingPlayer,
+                                    tagResolversToPlaceholders(placeholders));
+                        }
                     }
                 };
+
         movement.put(uuid, movementtimer);
         movementtimer.runTaskLater(CoreClass.getInstance(), warmUp * 20L);
         if ((MainConfig.get().CANCEL_WARM_UP_ON_MOVEMENT.get() && !teleportingPlayer.hasPermission("at.admin.bypass.movement"))
@@ -165,6 +205,32 @@ public class MovementManager implements Listener {
                     "Teleport.eventBeforeTPMovementAllowed",
                     Placeholder.unparsed("countdown", String.valueOf(warmUp)));
         }
+
+        if (toPlayer != null) {
+
+            CommandRunner.runCommandsOnWarmUp(
+                    command,
+                    location,
+                    payingPlayer,
+                    tagResolversToPlaceholders(
+                            placeholders, new CommandRunner.Placeholder("target",
+                                    command.equals("tpa") ? toPlayer.getName() : teleportingPlayer.getName())));
+        } else {
+            CommandRunner.runCommandsOnWarmUp(
+                    command,
+                    location,
+                    payingPlayer,
+                    tagResolversToPlaceholders(placeholders));
+        }
+    }
+
+    private static CommandRunner.Placeholder[] tagResolversToPlaceholders(TagResolver.Single[] resolvers, CommandRunner.Placeholder... otherPlaceholders) {
+        CommandRunner.Placeholder[] newPlaceholders = new CommandRunner.Placeholder[resolvers.length + otherPlaceholders.length];
+        for (int i = 0; i < resolvers.length; i++) {
+            TagResolver.Single resolver = resolvers[i];
+            newPlaceholders[i] = new CommandRunner.Placeholder(resolver.key(), resolver.tag());
+        }
+        return newPlaceholders;
     }
 
     public abstract static class ImprovedRunnable extends BukkitRunnable {

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/AcceptRequest.java
@@ -64,7 +64,7 @@ public class AcceptRequest {
         Player payingPlayer = type.equalsIgnoreCase("tpahere") ? toPlayer : fromPlayer;
         if (warmUp > 0 && !fromPlayer.hasPermission("at.admin.bypass.timer")) {
             MovementManager.createMovementTimer(
-                    fromPlayer, toLocation, type, "Teleport.eventTeleport", warmUp, payingPlayer);
+                    fromPlayer, toLocation, type, "Teleport.eventTeleport", warmUp, payingPlayer, toPlayer);
             return;
         }
         ATPlayer.teleportWithOptions(
@@ -76,5 +76,12 @@ public class AcceptRequest {
         if (MainConfig.get().APPLY_COOLDOWN_AFTER.get().equalsIgnoreCase("teleport")) {
             CooldownManager.addToCooldown(type, payingPlayer, toLocation.getWorld());
         }
+
+        CommandRunner.runCommandsOnTeleport(
+                type,
+                toLocation,
+                payingPlayer,
+                new CommandRunner.Placeholder("target",
+                                type.equals("tpa") ? toPlayer.getName() : fromPlayer.getName()));
     }
 }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/CommandRunner.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/CommandRunner.java
@@ -1,0 +1,138 @@
+package io.github.niestrat99.advancedteleport.utilities;
+
+import io.github.niestrat99.advancedteleport.CoreClass;
+import io.github.niestrat99.advancedteleport.config.MainConfig;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class CommandRunner {
+
+    public static void runCommandsOnWarmUp(final @NotNull String teleportCommand, final @NotNull Location location,
+                                           final @NotNull Player executor, final @NotNull Placeholder... placeholders) {
+
+        runCommands(MainConfig.get().COMMANDS_ON_WARM_UP,
+                teleportCommand,
+                executor,
+                addLocationPlaceholders(placeholders, location));
+    }
+
+    public static void runCommandsOnTeleport(final @NotNull String teleportCommand, final @NotNull Location location,
+                                             final @NotNull Player executor, final @NotNull Placeholder... placeholders) {
+
+        runCommands(
+                MainConfig.get().COMMANDS_ON_TELEPORT,
+                teleportCommand,
+                executor,
+                addLocationPlaceholders(placeholders, location));
+    }
+
+    public static void runCommandsOnCooldownExpire(final @NotNull String teleportCommand, final @NotNull Player affectedPlayer,
+                                                   final @NotNull Placeholder... placeholders) {
+
+        runCommands(
+                MainConfig.get().COMMANDS_ON_COOLDOWN_EXPIRE,
+                teleportCommand,
+                affectedPlayer,
+                placeholders);
+    }
+
+    public static void runCommandsOnCancel(final @NotNull String teleportCommand, final @NotNull Player affectedPlayer,
+                                           final @NotNull Placeholder... placeholders) {
+
+        runCommands(MainConfig.get().COMMANDS_ON_CANCEL,
+                teleportCommand,
+                affectedPlayer,
+                placeholders);
+    }
+
+    public static void runCommands(final @NotNull MainConfig.PerCommandOption<Object> configuration,
+                                   final @NotNull String teleportCommand,
+                                   final @NotNull Player executor, final @NotNull Placeholder... placeholders) {
+
+        final Placeholder[] finalPlaceholders = addPlaceholders(
+                placeholders,
+                new Placeholder("player", executor.getName()),
+                new Placeholder("command", teleportCommand));
+
+        Object commandList = configuration.valueOf(teleportCommand).get();
+        if (commandList instanceof String command) {
+            runCommand(executor, buildCommand(command, finalPlaceholders));
+        } else if (commandList instanceof List<?> commands) {
+
+            for (Object rawCommand : commands) {
+                if (rawCommand instanceof String command) {
+                    runCommand(executor, buildCommand(command, finalPlaceholders));
+                }
+            }
+        }
+    }
+
+    private static Command buildCommand(final @NotNull String rawCommand, final @NotNull Placeholder[] placeholders) {
+        String buildingCommand = rawCommand;
+        Sender sender = Sender.PLAYER;
+        if (buildingCommand.startsWith("server;")) {
+            buildingCommand = buildingCommand.substring("server;".length());
+            sender = Sender.SERVER;
+        } else if (buildingCommand.startsWith("player;")) {
+            buildingCommand = buildingCommand.substring("player;".length());
+        }
+
+        for (Placeholder placeholder : placeholders) {
+            buildingCommand = buildingCommand.replace("{" + placeholder.placeholder + "}", String.valueOf(placeholder.value));
+        }
+        return new Command(buildingCommand, sender);
+    }
+
+    private static void runCommand(final @NotNull Player executor, final @NotNull Command command) {
+        if (command.sender == Sender.PLAYER) {
+            if (!executor.performCommand(command.command)) {
+                CoreClass.getInstance().getLogger().warning("Command /" + command.command + " run by " + executor.getName() + " failed (returned false).");
+            }
+        } else {
+            if (!Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command.command)) {
+                CoreClass.getInstance().getLogger().warning("Command /" + command.command + " run in the console failed (returned false).");
+            }
+        }
+    }
+
+    private static Placeholder[] addPlaceholders(final @NotNull Placeholder[] currentPlaceholders,
+                                          final @NotNull Placeholder... newPlaceholders) {
+        Placeholder[] newArray = new Placeholder[currentPlaceholders.length + newPlaceholders.length];
+        System.arraycopy(currentPlaceholders, 0, newArray, 0, currentPlaceholders.length);
+        System.arraycopy(newPlaceholders, 0, newArray, currentPlaceholders.length, newPlaceholders.length);
+
+        return newArray;
+    }
+
+    private static Placeholder[] addLocationPlaceholders(final @NotNull Placeholder[] currentPlaceholders,
+                                                         final @NotNull Location location) {
+        return addPlaceholders(
+                currentPlaceholders,
+                new Placeholder("x", location.getX()),
+                new Placeholder("y", location.getY()),
+                new Placeholder("z", location.getZ()),
+                new Placeholder("block_x", location.getBlockX()),
+                new Placeholder("block_y", location.getBlockY()),
+                new Placeholder("block_z", location.getBlockZ()),
+                new Placeholder("yaw", location.getYaw()),
+                new Placeholder("pitch", location.getPitch()),
+                new Placeholder("world", location.getWorld().getName()));
+    }
+
+
+    private enum Sender {
+        PLAYER,
+        SERVER
+    }
+
+    public record Placeholder(String placeholder, Object value) {
+
+    }
+
+    private record Command(String command, Sender sender) {
+    }
+}


### PR DESCRIPTION
Adds options for certain commands to run when the teleport warm-up starts, the teleportation occurs, the command cooldown expires and the warm-up is cancelled.

Ideally, I would like to have this utilise the events API and set up extra events for some of these, but I can cover that separately in the future.