### PR TITLE
dev: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+### Information
+<!-- Provide information about what the purpose of the PR is. -->
+<!-- If the PR is linked to an issue in GitHub, provide the #issue-number too. -->
+
+### Prior to Merging
+- [ ] Does the PR need documenting on the wiki? If not, remove this, otherwise, leave this unchecked until a respective
+PR has been made for the wiki.
+- [ ] Has the PR been tested? 
+- [ ] Do you consent to GitHub Copilot also reviewing your changes? An actual developer will review your changes first.


### PR DESCRIPTION
Adds a PR template that prompts for information about each PR, and a checklist of things to do/verify prior to merging.