### PR TITLE
feat: add RTP on first join

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
@@ -84,6 +84,7 @@ public final class MainConfig extends ATConfig {
     public ConfigOption<Boolean> WHITELIST_WORLD;
     public ConfigOption<Boolean> REDIRECT_TO_WORLD;
     public ConfigOption<List<String>> ALLOWED_WORLDS;
+
     public ConfigOption<Integer> DEFAULT_HOMES_LIMIT;
     public ConfigOption<Boolean> ADD_BED_TO_HOMES;
     public ConfigOption<Boolean> DENY_HOMES_IF_OVER_LIMIT;
@@ -103,6 +104,9 @@ public final class MainConfig extends ATConfig {
     public MapOptions MAP_SPAWNS;
     public ConfigOption<Boolean> TELEPORT_TO_SPAWN_FIRST;
     public ConfigOption<String> FIRST_SPAWN_POINT;
+    public ConfigOption<Boolean> USE_RANDOM_LOCATION_FIRST_SPAWN_POINT;
+    public ConfigOption<String> FIRST_RANDOM_LOCATION_WORLD_NAME;
+    public ConfigOption<Boolean> SET_RANDOM_FIRST_LOCATION_HOME;
     public ConfigOption<Boolean> TELEPORT_TO_SPAWN_EVERY;
     public ConfigOption<Boolean> TELEPORT_TO_NEAREST_SPAWN;
     public ConfigOption<Boolean> USE_OVERWORLD;
@@ -817,6 +821,22 @@ public final class MainConfig extends ATConfig {
                 "The name of the spawnpoint players will be first teleported to if they joined for the first time.\n"
                         + "If it is blank, then it will take the main spawnpoint.");
         addDefault(
+                "use-random-location-for-first-spawn-point",
+                false,
+                "Teleports all new players to a random location when they join the server for the first time.");
+        addDefault(
+                "first-random-teleportation-world-name",
+                "",
+                """
+                        The world that the player will be randomly teleported into when they join for the first time.
+                        If left blank, the player will either teleport within the world of the main spawnpoint, or the
+                        world they first spawn in.""");
+        addDefault(
+                "set-first-random-location-as-home",
+                false,
+                "If players are teleported to a random location when they first join the server, this sets the\n" +
+                        "location as a home for those players called \"home\".");
+        addDefault(
                 "teleport-to-spawn-on-every-join",
                 false,
                 "Whether the player should be teleported to the spawnpoint every time they join.");
@@ -1167,6 +1187,9 @@ public final class MainConfig extends ATConfig {
 
         TELEPORT_TO_SPAWN_FIRST = new ConfigOption<>("teleport-to-spawn-on-first-join");
         FIRST_SPAWN_POINT = new ConfigOption<>("first-spawn-point");
+        USE_RANDOM_LOCATION_FIRST_SPAWN_POINT = new ConfigOption<>("use-random-location-for-first-spawn-point");
+        FIRST_RANDOM_LOCATION_WORLD_NAME = new ConfigOption<>("first-random-teleportation-world-name");
+        SET_RANDOM_FIRST_LOCATION_HOME = new ConfigOption<>("set-first-random-location-as-home");
         TELEPORT_TO_SPAWN_EVERY = new ConfigOption<>("teleport-to-spawn-on-every-join");
         TELEPORT_TO_NEAREST_SPAWN = new ConfigOption<>("teleport-to-nearest-spawnpoint");
         USE_OVERWORLD = new ConfigOption<>("use-overworld");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
@@ -15,6 +15,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -40,6 +41,7 @@ public class TeleportTrackingManager implements Listener {
         if (player.hasPermission("at.admin.bypass.teleport-on-join")) return;
 
         // If the player hasn't played before and needs teleporting, go there
+        boolean teleported = false;
         if (!player.hasPlayedBefore() && MainConfig.get().TELEPORT_TO_SPAWN_FIRST.get()) {
 
             final String name = MainConfig.get().FIRST_SPAWN_POINT.get();
@@ -47,10 +49,11 @@ public class TeleportTrackingManager implements Listener {
 
             // If the spawn exists, go there, otherwise alert the admins
             if (spawn != null) {
-                spawn(player, spawn);
-                return;
+                spawn(player, spawn.getLocation());
+                teleported = true;
             } else if (name.isEmpty() && AdvancedTeleportAPI.getMainSpawn() != null) {
-                spawn(player, AdvancedTeleportAPI.getMainSpawn());
+                spawn(player, AdvancedTeleportAPI.getMainSpawn().getLocation());
+                teleported = true;
             } else {
                 CoreClass.getInstance()
                         .getLogger()
@@ -58,21 +61,57 @@ public class TeleportTrackingManager implements Listener {
             }
         }
 
+        if (!player.hasPlayedBefore() && MainConfig.get().USE_RANDOM_LOCATION_FIRST_SPAWN_POINT.get()) {
+
+            String worldName = MainConfig.get().FIRST_RANDOM_LOCATION_WORLD_NAME.get();
+            if (worldName == null || worldName.isEmpty()) {
+                if (AdvancedTeleportAPI.getMainSpawn() != null) {
+                    worldName = AdvancedTeleportAPI.getMainSpawn().getName();
+                }
+            }
+
+            World targetWorld = worldName == null || worldName.isEmpty() ? player.getWorld() : Bukkit.getWorld(worldName);
+            if (targetWorld != null) {
+
+                teleported = true;
+                AdvancedTeleportAPI.getRandomLocation(targetWorld, player).whenCompleteAsync((result, err) -> {
+
+                    if (err != null) {
+                        CoreClass.getInstance().getLogger().warning("Failed to randomly teleport " + player.getName()
+                                + " on their first join! No location could be found.");
+                        return;
+                    }
+
+                    ATPlayer atPlayer = ATPlayer.getPlayer(player);
+                    spawn(player, result);
+                    InvulnerabilityManager.createInvulnerability(player, atPlayer.getInvulnerability("tpr", result.getWorld()));
+                    ParticleManager.onPostTeleport(player, "tpr");
+
+                    if (MainConfig.get().USE_HOMES.get() && MainConfig.get().SET_RANDOM_FIRST_LOCATION_HOME.get()) {
+                        atPlayer.addHome("home", result);
+                    }
+                }, CoreClass.sync);
+            } else {
+                CoreClass.getInstance().getLogger().warning("Failed to randomly teleport " + player.getName()
+                        + " on their first join! The target world (" + worldName + ") either doesn't exist or wasn't specified.");
+            }
+        }
+
         // If the player has played before but needs to be sent to spawn every login, go there
-        if (MainConfig.get().TELEPORT_TO_SPAWN_EVERY.get()) {
+        if (!teleported && MainConfig.get().TELEPORT_TO_SPAWN_EVERY.get()) {
             final Spawn spawn = AdvancedTeleportAPI.getDestinationSpawn(player.getWorld(), player);
-            spawn(player, spawn);
+            spawn(player, spawn.getLocation());
         }
     }
 
-    private void spawn(Player player, Spawn spawn) {
+    private void spawn(Player player, Location spawn) {
         Bukkit.getScheduler()
                 .runTaskLater(
                         CoreClass.getInstance(),
                         () ->
                                 ATPlayer.teleportWithOptions(
                                                 player,
-                                                spawn.getLocation(),
+                                                spawn,
                                                 PlayerTeleportEvent.TeleportCause.PLUGIN)
                                         .whenComplete(
                                                 (result, err) -> {


### PR DESCRIPTION
### Information
Closes #57 - allows for RTP'ing on the first join, and saves the teleported location as a home (god this is an old one)

### Prior to Merging
- [x] Does the PR need documenting on the wiki? If not, remove this, otherwise, leave this unchecked until a respective
PR has been made for the wiki.
- [x] Has the PR been tested? 
- [x] Do you consent to GitHub Copilot also reviewing your changes? An actual developer will review your changes first.