### PR TITLE
fix: Wrong message displaying when trying to set a home without arguments while having home limit reached.

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
@@ -42,7 +42,7 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
             if (atPlayer.getHomes().isEmpty() && (limit > 0 || limit == -1)) {
                 setHome(player, "home");
                 return true;
-            } else if (atPlayer.getHomes().size() >= limit) { // If player has reached the homes limit already.
+            } else if (!atPlayer.canSetMoreHomes()) { // If player has reached the homes limit already.
                 CustomMessages.sendMessage(sender, "Error.reachedHomeLimit");
                 return false;
             }

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/commands/home/SetHomeCommand.java
@@ -42,6 +42,9 @@ public final class SetHomeCommand extends AbstractHomeCommand implements PlayerC
             if (atPlayer.getHomes().isEmpty() && (limit > 0 || limit == -1)) {
                 setHome(player, "home");
                 return true;
+            } else if (atPlayer.getHomes().size() >= limit) { // If player has reached the homes limit already.
+                CustomMessages.sendMessage(sender, "Error.reachedHomeLimit");
+                return false;
             }
 
             // If the player is a floodgate player, send them a form, otherwise tell the player to


### PR DESCRIPTION
### Information
<!-- Provide information about what the purpose of the PR is. --> This change should fix an issue where the plugin would tell you to include a home name rather than telling you that you have reached your max homes when trying to set one.
<!-- If the PR is linked to an issue in GitHub, provide the #issue-number too. -->

### Prior to Merging
- [ ] Does the PR need documenting on the wiki? If not, remove this, otherwise, leave this unchecked until a respective
PR has been made for the wiki.
- [x] Has the PR been tested? 
- [x] Do you consent to GitHub Copilot also reviewing your changes? An actual developer will review your changes first.