### PR TITLE
feat: add per-warp distance overrides

### DIFF
--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
@@ -67,6 +67,7 @@ public final class MainConfig extends ATConfig {
     public ConfigOption<Boolean> MONITOR_ALL_TELEPORTS;
     public PerCommandOption<Integer> DISTANCE_LIMITS;
     public ConfigOption<ConfigSection> CUSTOM_DISTANCE_LIMITS;
+    public ConfigOption<ConfigSection> WARP_DISTANCE_OVERRIDES;
     public ConfigOption<Boolean> ENABLE_TELEPORT_LIMITATIONS;
     public ConfigOption<Boolean> MONITOR_ALL_TELEPORTS_LIMITS;
     public ConfigOption<ConfigSection> WORLD_RULES;
@@ -495,6 +496,19 @@ public final class MainConfig extends ATConfig {
                 The key (vip-distance) and group name (VIP) do not have to be different, this is just an example.
                 You can also add at.member.distance.300000, but this is more efficient if you find permissions lag. To make it per-command, use at.member.distance.<command>.vip-distance. To make it per-world, use at.member.distance.<world>.vip-distance.
                 To combine the two, you can use at.member.distance.<command>.<world>.vip-distance.\
+                """);
+
+        makeSectionLenient("warp-distance-overrides");
+        addComment(
+                "warp-distance-overrides",
+                """
+                Per-warp distance overrides.
+                Set a specific distance limit for individual warps.
+                Use -1 to remove the distance limit entirely for that warp.
+                Example:
+                warp-distance-overrides:
+                  caverns: -1
+                  temple: 5000\
                 """);
 
         addSection("Teleportation Limitations");
@@ -1145,6 +1159,7 @@ public final class MainConfig extends ATConfig {
                 new PerCommandOption<>(
                         "per-command-distance-limitations", "maximum-teleport-distance");
         CUSTOM_DISTANCE_LIMITS = new ConfigOption<>("custom-distance-limitations");
+        WARP_DISTANCE_OVERRIDES = new ConfigOption<>("warp-distance-overrides");
 
         ENABLE_TELEPORT_LIMITATIONS = new ConfigOption<>("enable-teleport-limitations");
         MONITOR_ALL_TELEPORTS_LIMITS = new ConfigOption<>("monitor-all-teleports-limitations");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
@@ -502,7 +502,6 @@ public final class MainConfig extends ATConfig {
         addComment(
                 "warp-distance-overrides",
                 """
-                Per-warp distance overrides.
                 Set a specific distance limit for individual warps.
                 Use -1 to remove the distance limit entirely for that warp.
                 Example:

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/TeleportTrackingManager.java
@@ -166,7 +166,8 @@ public class TeleportTrackingManager implements Listener {
                         e.getFromLocation(),
                         e.getToLocation(),
                         e.getType().getName(),
-                        e.getPlayer());
+                        e.getPlayer(),
+                        e.getLocName());
         if (result != null) {
             CustomMessages.sendMessage(
                     e.getPlayer(),

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/ConditionChecker.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/ConditionChecker.java
@@ -64,6 +64,12 @@ public class ConditionChecker {
 
     public static @Nullable String canTeleport(
             Location fromLoc, Location toLoc, String command, Player teleportingPlayer) {
+        return canTeleport(fromLoc, toLoc, command, teleportingPlayer, null);
+    }
+
+    public static @Nullable String canTeleport(
+            Location fromLoc, Location toLoc, String command, Player teleportingPlayer,
+            @Nullable String locName) {
 
         // Use debug print
         CoreClass.debug(
@@ -81,7 +87,7 @@ public class ConditionChecker {
                 && !teleportingPlayer.hasPermission("at.admin.bypass.distance-limit")
                 && fromLoc.getWorld() == toLoc.getWorld()
                 && !DistanceLimiter.canTeleport(
-                        toLoc, fromLoc, command, ATPlayer.getPlayer(teleportingPlayer))) {
+                        toLoc, fromLoc, command, ATPlayer.getPlayer(teleportingPlayer), locName)) {
             return "Error.tooFarAway";
         }
 

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/DistanceLimiter.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/utilities/DistanceLimiter.java
@@ -3,13 +3,38 @@ package io.github.niestrat99.advancedteleport.utilities;
 import io.github.niestrat99.advancedteleport.api.ATPlayer;
 import io.github.niestrat99.advancedteleport.config.MainConfig;
 
+import io.github.thatsmusic99.configurationmaster.api.ConfigSection;
 import org.bukkit.Location;
+import org.jetbrains.annotations.Nullable;
 
 public class DistanceLimiter {
 
     public static boolean canTeleport(
             Location loc1, Location loc2, String command, ATPlayer player) {
+        return canTeleport(loc1, loc2, command, player, null);
+    }
+
+    public static boolean canTeleport(
+            Location loc1, Location loc2, String command, ATPlayer player, @Nullable String locName) {
         if (command == null && !MainConfig.get().MONITOR_ALL_TELEPORTS.get()) return true;
+
+        // Check for per-warp distance overrides when the command is "warp"
+        if ("warp".equalsIgnoreCase(command) && locName != null && !locName.isEmpty()) {
+            ConfigSection overrides = MainConfig.get().WARP_DISTANCE_OVERRIDES.get();
+            if (overrides != null) {
+                Object overrideValue = overrides.get(locName);
+                if (overrideValue != null) {
+                    int overrideDistance = overrides.getInteger(locName);
+                    if (overrideDistance == -1) return true;
+                    if (overrideDistance > 0) {
+                        if (!MainConfig.get().ENABLE_DISTANCE_LIMITATIONS.get()) return true;
+                        if (loc1.getWorld() != loc2.getWorld()) return true;
+                        return loc1.distanceSquared(loc2) < (long) overrideDistance * overrideDistance;
+                    }
+                }
+            }
+        }
+
         int allowedDistance = player.getDistanceLimitation(command, loc2.getWorld());
         if (MainConfig.get().ENABLE_DISTANCE_LIMITATIONS.get() && allowedDistance > 0) {
             if (loc1.getWorld() != loc2.getWorld()) return true;

--- a/config/config.yml
+++ b/config/config.yml
@@ -226,6 +226,13 @@ per-command-distance-limitations:
   # Distance limit for /back
   back: default
 
+# Per-warp distance overrides.
+# Set a specific distance limit for individual warps.
+# Use -1 to remove the distance limit entirely for that warp.
+# warp-distance-overrides:
+#   caverns: -1
+#   temple: 5000
+
 ###############################
 #  Teleportation Limitations  #
 ###############################


### PR DESCRIPTION
### Information

Adds a `warp-distance-overrides` config section that allows admins to set a custom distance limit for individual warps when `enable-distance-limitations` is enabled. Closes #145.

**Problem:** The distance limiter applies uniformly to all warps. Admins who want to restrict casual `/warp` usage to nearby areas have no way to exempt specific warps (server landmarks, community builds, dungeons) without granting `at.admin.bypass.distance-limit`, which bypasses ALL distance checks.

**Solution:** New config section where admins can specify per-warp overrides:
```yaml
warp-distance-overrides:
  caverns: -1      # No distance limit
  temple: -1       # No distance limit
  market: 5000     # Custom 5000 block limit
```
- `-1` removes the distance limit entirely for that warp
- Positive values override the default `maximum-teleport-distance` for that warp
- Warps not listed continue to use the normal distance limit
- Only affects the `warp` command; other teleport commands (tpa, home, spawn, back) are unaffected
- The `at.admin.bypass.distance-limit` permission still works as before
- Cross-world warps still bypass distance checks (existing behavior)

**Files changed:**
- `config/config.yml` — Added commented-out example section
- `MainConfig.java` — Registered `WARP_DISTANCE_OVERRIDES` config option
- `DistanceLimiter.java` — Added overload that checks warp overrides before falling through to normal behavior
- `ConditionChecker.java` — Added overload to pass location name through to `DistanceLimiter`
- `TeleportTrackingManager.java` — Passes `locName` from `ATTeleportEvent` to `ConditionChecker`

### Prior to Merging
- [ ] Does the PR need documenting on the wiki? If not, remove this, otherwise, leave this unchecked until a respective PR has been made for the wiki.
- [x] Has the PR been tested?
- [x] Do you consent to GitHub Copilot also reviewing your changes? An actual developer will review your changes first.