### PR TITLE
feat: add [Town Spawn] interactive sign (Towny integration)

### DIFF
--- a/AdvancedTeleport-Bukkit/build.gradle.kts
+++ b/AdvancedTeleport-Bukkit/build.gradle.kts
@@ -246,7 +246,7 @@ bukkit {
     main = "io.github.niestrat99.advancedteleport.CoreClass"
     load = BukkitPluginDescription.PluginLoadOrder.POSTWORLD
 
-    softDepend = listOf("Vault", "Ultimate_Economy", "ConfigurationMaster", "WorldBorder", "ChunkyBorder", "floodgate", "Lands", "WorldGuard", "GriefProtection", "dynmap", "squaremap", "PlayerParticles")
+    softDepend = listOf("Vault", "Ultimate_Economy", "ConfigurationMaster", "WorldBorder", "ChunkyBorder", "floodgate", "Lands", "WorldGuard", "GriefProtection", "dynmap", "squaremap", "PlayerParticles", "Towny")
     loadBefore = listOf("Essentials", "EssentialsSpawn")
 
     commands {
@@ -553,6 +553,7 @@ bukkit {
                 "at.member.warp.use-sign" to true,
                 "at.member.warps.use-sign" to true,
                 "at.member.bed.use-sign" to true,
+                "at.member.townspawn.use-sign" to true,
                 "at.member.back.death" to true,
                 "at.member.warps.location" to true,
                 "at.member.homes.location" to true,
@@ -597,6 +598,7 @@ bukkit {
                 "at.admin.sign.warp.create" to true,
                 "at.admin.sign.warps.create" to true,
                 "at.admin.sign.bed.create" to true,
+                "at.admin.sign.townspawn.create" to true,
                 "at.admin.tpoffline" to true,
                 "at.admin.tpofflinehere" to true,
                 "at.member.homes.unlimited" to true

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/signs/TownSpawnSign.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/api/signs/TownSpawnSign.java
@@ -1,0 +1,32 @@
+package io.github.niestrat99.advancedteleport.api.signs;
+
+import io.github.niestrat99.advancedteleport.api.ATSign;
+import io.github.niestrat99.advancedteleport.config.MainConfig;
+import net.kyori.adventure.text.Component;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class TownSpawnSign extends ATSign {
+
+    public TownSpawnSign() {
+        super("TownSpawn", MainConfig.get().USE_TOWNY.get());
+    }
+
+    @Override
+    public void onInteract(@NotNull Sign sign, @NotNull Player player) {
+        String townName = sign.getLine(1).trim();
+        if (townName.isEmpty()) {
+            player.performCommand("town spawn");
+        } else {
+            player.performCommand("town spawn " + townName);
+        }
+    }
+
+    @Override
+    public boolean canCreate(final @NotNull List<Component> lines, final @NotNull Player player) {
+        return true;
+    }
+}

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/CustomMessages.java
@@ -807,6 +807,7 @@ public final class CustomMessages extends ATConfig {
         addDefault("Signs.spawn", "<blue><bold>[Spawn]</bold></blue>");
         addDefault("Signs.warp", "<blue><bold>[Warp]</bold></blue>");
         addDefault("Signs.warps", "<blue><bold>[Warps]</bold></blue>");
+        addDefault("Signs.townspawn", "<blue><bold>[Town Spawn]</bold></blue>");
 
         addFormsDefault(
                 "tpahere", "TPAHere Request", "Select a player to send a TPAHere request to.");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/config/MainConfig.java
@@ -23,6 +23,7 @@ public final class MainConfig extends ATConfig {
     public ConfigOption<Boolean> USE_RANDOMTP;
     public ConfigOption<Boolean> USE_SPAWN;
     public ConfigOption<Boolean> USE_HOMES;
+    public ConfigOption<Boolean> USE_TOWNY;
     public ConfigOption<List<String>> DISABLED_COMMANDS;
     public ConfigOption<Integer> REQUEST_LIFETIME;
     public ConfigOption<Boolean> USE_MULTIPLE_REQUESTS;
@@ -166,6 +167,7 @@ public final class MainConfig extends ATConfig {
         addDefault("use-spawn", true, "Whether the plugin should modify spawn/spawn properties.");
         addDefault("use-randomtp", true, "Whether the plugin should allow random teleportation.");
         addDefault("use-homes", true, "Whether homes should be enabled in the plugin.");
+        addDefault("use-towny", false, "Whether Towny integration features (e.g. Town Spawn signs) should be enabled. Requires Towny to be installed.");
         addDefault(
                 "disabled-commands",
                 new ArrayList<>(),
@@ -1073,6 +1075,7 @@ public final class MainConfig extends ATConfig {
         USE_RANDOMTP = new ConfigOption<>("use-randomtp");
         USE_SPAWN = new ConfigOption<>("use-spawn");
         USE_HOMES = new ConfigOption<>("use-homes");
+        USE_TOWNY = new ConfigOption<>("use-towny");
         DISABLED_COMMANDS = new ConfigOption<>("disabled-commands");
 
         REQUEST_LIFETIME = new ConfigOption<>("request-lifetime");

--- a/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/SignManager.java
+++ b/AdvancedTeleport-Bukkit/src/main/java/io/github/niestrat99/advancedteleport/managers/SignManager.java
@@ -4,8 +4,10 @@ import io.github.niestrat99.advancedteleport.api.ATSign;
 import io.github.niestrat99.advancedteleport.api.AdvancedTeleportAPI;
 import io.github.niestrat99.advancedteleport.api.signs.*;
 import io.github.niestrat99.advancedteleport.CoreClass;
+import io.github.niestrat99.advancedteleport.config.MainConfig;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,6 +30,15 @@ public class SignManager {
         AdvancedTeleportAPI.registerSign("bed", new BedSign());
         AdvancedTeleportAPI.registerSign("spawn", new SpawnSign());
         AdvancedTeleportAPI.registerSign("randomtp", new RandomTPSign());
+
+        if (MainConfig.get().USE_TOWNY.get()) {
+            if (Bukkit.getPluginManager().getPlugin("Towny") != null) {
+                AdvancedTeleportAPI.registerSign("townspawn", new TownSpawnSign());
+            } else {
+                CoreClass.getInstance().getLogger().warning("Towny integration is enabled in config but Towny is not installed. Town Spawn signs will not be available.");
+            }
+        }
+
 	CoreClass.debug("Registered " + this.signs.size() + " signs.");
     }
 


### PR DESCRIPTION
### Information

Adds a new `[Town Spawn]` interactive sign type that integrates with Towny by dispatching `town spawn` as the clicking player via `player.performCommand()`. This delegates all permission and access checking to Towny itself.

**Behavior:**
- Line 1: `[Town Spawn]` (sign type identifier)
- Line 2 empty: runs `town spawn` (player's own town)
- Line 2 has text: runs `town spawn <townname>` (specific town)

**Implementation details:**
- No compile-time dependency on Towny, uses string-based command dispatch only
- Disabled by default (`use-towny: false`) and must be explicitly enabled in config
- Logs a warning if enabled without Towny installed
- Towny added to `softDepend` so it loads before AT when present
- Follows existing sign patterns (`SpawnSign` as closest reference)
- Permissions: `at.member.townspawn.use-sign` (use) and `at.admin.sign.townspawn.create` (place)
- Display name: `<blue><bold>[Town Spawn]</bold></blue>` matching existing sign styling

**Files changed:**
- **New:** `TownSpawnSign.java` - sign class extending `ATSign`
- `MainConfig.java` - `USE_TOWNY` config option (field, default, initialization)
- `SignManager.java` - conditional registration with Towny presence check
- `CustomMessages.java` - `Signs.townspawn` display name
- `build.gradle.kts` - softDepend, member and admin permissions

### Prior to Merging
- [ ] Does the PR need documenting on the wiki? If not, remove this, otherwise, leave this unchecked until a respective
PR has been made for the wiki.
- [x] Has the PR been tested?
- [x] Do you consent to GitHub Copilot also reviewing your changes? An actual developer will review your changes first.